### PR TITLE
feat(auth): 从本机浏览器自动导入登录态 — 零认知负荷登录

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "tenacity>=8.2",
   "mcp>=1.2",
   "websockets>=13",
+  "browser-cookie3>=0.20",
 ]
 
 [project.optional-dependencies]

--- a/src/goofish_cli/commands/auth/login.py
+++ b/src/goofish_cli/commands/auth/login.py
@@ -1,49 +1,92 @@
-"""auth login — 导入 cookie 到 ~/.goofish-cli/cookies.json。
+"""auth login — 导入闲鱼登录态到 ~/.goofish-cli/cookies.json。
 
-支持两种格式：
-- Chrome 扩展导出的 JSON 数组 [{"name":"...","value":"..."}]
-- cookie 字符串 "k=v; k=v"（--raw）
+默认行为（零参数）：从本机所有已装浏览器中自动探测 → 最低认知负荷。
+支持的浏览器：Chrome / Edge / Brave / Chromium / Opera / OperaGX / Vivaldi
+            / Arc / Firefox / LibreWolf / Safari（由 browser_cookie3 提供）。
+
+降级路径：
+
+- `auth login`                     自动 auto-detect（推荐）
+- `auth login --browser edge`      指定单个浏览器
+- `auth login <path>`              从 JSON 文件导入
+- `auth login <cookie_str> --raw`  粘贴 "k=v; k=v" 字符串
+
+触发条件：
+1. 所有浏览器都没拿到 → 报错里列出手动兜底方案
+2. 环境变量 GOOFISH_NO_CHROME_BOOTSTRAP=1 只影响其它命令启动时的
+   Session.load 自动 bootstrap，不影响本命令。
 """
+from __future__ import annotations
 
 import json
 from pathlib import Path
 
 from goofish_cli.core import Strategy, command
-from goofish_cli.core.session import DEFAULT_COOKIE_PATH
+from goofish_cli.core.errors import AuthRequiredError
+from goofish_cli.core.session import DEFAULT_COOKIE_PATH, write_cookies_json
 
 
 @command(
     namespace="auth",
     name="login",
-    description="从 JSON 文件或 cookie 字符串导入登录态",
+    description="导入登录态（默认从本机浏览器 auto-detect；支持 Chrome/Edge/Brave/Safari/Firefox 等）",
     strategy=Strategy.PUBLIC,
-    columns=["path", "unb", "tracknick", "cookies_count"],
+    columns=["source", "path", "unb", "tracknick", "cookies_count"],
 )
-def login(source: str, *, raw: bool = False) -> dict[str, object]:
-    if raw:
+def login(
+    source: str | None = None,
+    *,
+    raw: bool = False,
+    browser: str = "auto",
+) -> dict[str, object]:
+    target = DEFAULT_COOKIE_PATH
+
+    if source is None:
+        cookies, source_label = _pull_from_browser(browser)
+    elif raw:
         cookies = _parse_raw(source)
+        source_label = "raw"
     else:
         p = Path(source).expanduser()
         cookies = _parse_json(p.read_text())
+        source_label = f"file:{p}"
 
     if "unb" not in cookies or "_m_h5_tk" not in cookies:
-        raise ValueError("cookie 缺失关键字段 unb / _m_h5_tk，请重新从浏览器导出")
+        raise AuthRequiredError(
+            "cookie 缺失关键字段 unb / _m_h5_tk。"
+            "请先在浏览器里登录 https://www.goofish.com 再试。"
+        )
 
-    target = DEFAULT_COOKIE_PATH
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(json.dumps(
-        [{"name": k, "value": v} for k, v in cookies.items()],
-        ensure_ascii=False,
-        indent=2,
-    ))
-    target.chmod(0o600)
+    write_cookies_json(target, cookies)
 
     return {
+        "source": source_label,
         "path": str(target),
         "unb": cookies.get("unb", ""),
         "tracknick": cookies.get("tracknick", ""),
         "cookies_count": len(cookies),
     }
+
+
+def _pull_from_browser(browser: str) -> tuple[dict[str, str], str]:
+    from goofish_cli.core.browser_cookie import (
+        BrowserCookieError,
+        available_browsers,
+        extract_goofish_cookies,
+    )
+    try:
+        used, cookies = extract_goofish_cookies(browser=browser)
+        return cookies, f"browser:{used}"
+    except BrowserCookieError as e:
+        supported = ", ".join(available_browsers())
+        raise AuthRequiredError(
+            f"浏览器登录态导入失败：{e}\n"
+            f"兜底方案：\n"
+            f"  1. 确认已在任一浏览器里登录 https://www.goofish.com 后重试\n"
+            f"  2. 指定具体浏览器：`goofish auth login --browser edge`（支持：{supported}）\n"
+            f"  3. 手动导出 JSON：`goofish auth login ~/Downloads/cookies.json`\n"
+            f"  4. 粘 cookie 字符串：`goofish auth login 'unb=...; _m_h5_tk=...' --raw`"
+        ) from e
 
 
 def _parse_raw(raw: str) -> dict[str, str]:
@@ -63,4 +106,4 @@ def _parse_json(text: str) -> dict[str, str]:
         return {c["name"]: c["value"] for c in data if "name" in c and "value" in c}
     if isinstance(data, dict):
         return {str(k): str(v) for k, v in data.items()}
-    raise ValueError("cookie JSON 格式不识别（需 list 或 dict）")
+    raise AuthRequiredError("cookie JSON 格式不识别（需 list 或 dict）")

--- a/src/goofish_cli/core/__init__.py
+++ b/src/goofish_cli/core/__init__.py
@@ -1,5 +1,7 @@
 from goofish_cli.core.errors import (
     AuthRequiredError,
+    BlockedError,
+    EmptyResultError,
     GoofishError,
     NotFoundError,
     RateLimitedError,
@@ -12,7 +14,9 @@ from goofish_cli.core.strategy import Strategy
 
 __all__ = [
     "AuthRequiredError",
+    "BlockedError",
     "Command",
+    "EmptyResultError",
     "GoofishError",
     "NotFoundError",
     "RateLimitedError",

--- a/src/goofish_cli/core/browser_cookie.py
+++ b/src/goofish_cli/core/browser_cookie.py
@@ -1,0 +1,232 @@
+"""从本机浏览器直接读取闲鱼登录态。
+
+参考 xiaohongshu-cli 的 auto-detect 设计——底层用 browser_cookie3 覆盖所有主流
+浏览器（Chrome / Edge / Brave / Chromium / Opera / OperaGX / Vivaldi / Arc /
+Firefox / LibreWolf / Safari），无需手写 Keychain / DPAPI 解密。
+
+对应 opencli 的 Strategy.COOKIE——复用已登录的浏览器会话，让用户不用手动
+从 DevTools 导出 JSON。区别在于 opencli 走 CDP 连"运行中的 Chrome"，我们走
+磁盘直读（不需要浏览器处在运行状态，更适合 CLI 场景）。
+
+双路兜底：
+1. in-process：直接 import + 调 browser_cookie3 —— 最快，大部分场景够用
+2. subprocess：fork 子进程跑，规避某些环境下 macOS Keychain 对主进程的限制
+"""
+from __future__ import annotations
+
+import functools
+import json
+import subprocess
+import sys
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from typing import Any
+
+from loguru import logger
+
+# 闲鱼/淘系登录态涉及的域。browser_cookie3 的 domain_name 是子串匹配，
+# 传 goofish.com 能覆盖 .goofish.com / www.goofish.com。为了不漏掉散落在
+# 淘系其它子域的关键 cookie（unb/_m_h5_tk 历史上就跨 .taobao.com），
+# 我们分别拉一遍后合并。
+GOOFISH_DOMAINS = ("goofish.com", "taobao.com")
+
+# 至少要拿到这些字段才算"登录态有效"
+REQUIRED_KEYS = ("unb", "_m_h5_tk")
+
+
+class BrowserCookieError(Exception):
+    """读取浏览器 cookie 失败的细分场景。不直接抛给最终用户——
+    上层 Session.load / auth login 应捕获后再转成 AuthRequiredError。"""
+
+
+# ── browser_cookie3 反射：枚举可用浏览器 ──────────────────────────────────
+
+@functools.lru_cache(maxsize=1)
+def available_browsers() -> tuple[str, ...]:
+    """列出 browser_cookie3 支持、且接受 domain_name 参数的 loader 名称。
+
+    反射方式比硬编码稳——browser_cookie3 升级加/减浏览器自动同步。
+    过滤掉 `load`（它内部自己遍历所有浏览器，和我们的 auto 模式功能重叠）。
+    """
+    import inspect
+
+    import browser_cookie3 as bc3
+
+    return tuple(sorted(
+        name
+        for name in dir(bc3)
+        if not name.startswith("_")
+        and name != "load"
+        and callable(getattr(bc3, name))
+        and hasattr(getattr(bc3, name), "__code__")
+        and "domain_name" in inspect.signature(getattr(bc3, name)).parameters
+    ))
+
+
+def _get_loader(browser: str):
+    import browser_cookie3 as bc3
+    loader = getattr(bc3, browser, None)
+    if loader is None or not callable(loader):
+        raise BrowserCookieError(
+            f"不认识的浏览器：{browser!r}。支持列表：{', '.join(available_browsers())}"
+        )
+    return loader
+
+
+# ── 单个浏览器的 in-process / subprocess 双路 ────────────────────────────
+
+def _extract_in_process(browser: str) -> dict[str, str] | None:
+    """直接 import browser_cookie3 调 loader。"""
+    try:
+        loader = _get_loader(browser)
+    except (ImportError, BrowserCookieError) as e:
+        logger.trace(f"{browser} in-process loader 获取失败：{e}")
+        return None
+
+    try:
+        jars = [loader(domain_name=domain) for domain in GOOFISH_DOMAINS]
+    except Exception as e:  # noqa: BLE001 — 浏览器没装/DB 锁/密钥解密失败都走这里
+        logger.trace(f"{browser} in-process 抽取失败：{e}")
+        return None
+
+    return _jars_to_dict(jars)
+
+
+def _extract_via_subprocess(browser: str) -> dict[str, str] | None:
+    """fork 子进程跑 browser_cookie3。macOS Keychain 对主进程和子进程的
+    授权作用域有时不一致，子进程兜底能救一些 Edge Case（也是 xhs-cli 的做法）。"""
+    script = '''
+import json, sys
+try:
+    import browser_cookie3 as bc3
+except ImportError:
+    print(json.dumps({"error": "browser-cookie3-not-installed"})); sys.exit(0)
+
+browser = sys.argv[1]
+domains = sys.argv[2].split(",")
+loader = getattr(bc3, browser, None)
+if not loader or not callable(loader):
+    print(json.dumps({"error": f"unknown-browser:{browser}"})); sys.exit(0)
+
+out = {}
+for d in domains:
+    try:
+        for c in loader(domain_name=d):
+            host = (c.domain or "").lstrip(".")
+            if any(h in host for h in ("goofish.com", "taobao.com", "tmall.com", "alibaba.com", "alicdn.com", "aliyun.com")):
+                out[c.name] = c.value
+    except Exception as e:
+        print(json.dumps({"error": f"extract-fail:{e}"})); sys.exit(0)
+print(json.dumps({"cookies": out}))
+'''
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", script, browser, ",".join(GOOFISH_DOMAINS)],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        logger.trace(f"{browser} subprocess 调用失败：{e}")
+        return None
+
+    if result.returncode != 0:
+        logger.trace(f"{browser} subprocess 退出非零：{result.stderr.strip()}")
+        return None
+
+    try:
+        data = json.loads(result.stdout.strip() or "{}")
+    except json.JSONDecodeError as e:
+        logger.trace(f"{browser} subprocess 输出非 JSON：{e}")
+        return None
+
+    if "error" in data:
+        logger.trace(f"{browser} subprocess 抽取失败：{data['error']}")
+        return None
+
+    return data.get("cookies") or None
+
+
+def _jars_to_dict(jars: list[Any]) -> dict[str, str]:
+    """从多个 CookieJar 合并筛出阿里系域 cookie。"""
+    allowed_hosts = (
+        "goofish.com", "taobao.com", "tmall.com",
+        "alibaba.com", "alicdn.com", "aliyun.com", "mmstat.com",
+    )
+    out: dict[str, str] = {}
+    for jar in jars:
+        for cookie in jar:
+            host = (cookie.domain or "").lstrip(".")
+            if not any(h in host for h in allowed_hosts):
+                continue
+            # 同名后写覆盖前 —— 这里没法判优先级，实测取到 unb/_m_h5_tk 都 OK
+            out[cookie.name] = cookie.value
+    return out
+
+
+def _try_browser(browser: str) -> dict[str, str] | None:
+    """顺序走 in-process → subprocess。任一路径拿到 REQUIRED_KEYS 就返回。"""
+    cookies = _extract_in_process(browser)
+    if cookies and _is_valid(cookies):
+        return cookies
+    cookies = _extract_via_subprocess(browser)
+    if cookies and _is_valid(cookies):
+        return cookies
+    return None
+
+
+def _is_valid(cookies: dict[str, str]) -> bool:
+    return all(k in cookies and cookies[k] for k in REQUIRED_KEYS)
+
+
+# ── 对外主入口 ────────────────────────────────────────────────────────────
+
+def extract_goofish_cookies(
+    browser: str = "auto",
+    *,
+    max_workers: int = 4,
+) -> tuple[str, dict[str, str]]:
+    """抽闲鱼登录态。
+
+    返回 (browser_name, cookies)。
+
+    browser:
+      - 'auto'：并发尝试所有已装浏览器，第一个拿到有效 cookie 的就用
+      - 具体浏览器名（chrome / edge / brave / safari / firefox / ...）
+
+    REQUIRED_KEYS 缺失 → 抛 BrowserCookieError，由上层转成 AuthRequiredError。
+    """
+    if browser != "auto":
+        cookies = _try_browser(browser)
+        if cookies:
+            return browser, cookies
+        raise BrowserCookieError(
+            f"{browser} 里没找到有效的闲鱼登录态（缺 unb / _m_h5_tk）。"
+            f"请先在 {browser} 里登录 https://www.goofish.com。"
+        )
+
+    browsers = available_browsers()
+    if not browsers:
+        raise BrowserCookieError(
+            "browser_cookie3 没枚举到任何浏览器。"
+            "请确认安装：`pip install browser-cookie3`。"
+        )
+
+    # 并发试所有浏览器，FIRST_COMPLETED 拿到就 cancel 其他
+    with ThreadPoolExecutor(max_workers=min(max_workers, len(browsers))) as pool:
+        future_to_browser = {pool.submit(_try_browser, b): b for b in browsers}
+        pending = set(future_to_browser)
+        while pending:
+            done, pending = wait(pending, return_when=FIRST_COMPLETED)
+            for fut in done:
+                cookies = fut.result()
+                if cookies:
+                    # 拿到就返回；其它线程让它们自己跑完（cancel 对正在执行的 future 无效）
+                    for p in pending:
+                        p.cancel()
+                    return future_to_browser[fut], cookies
+
+    tried = ", ".join(browsers)
+    raise BrowserCookieError(
+        f"所有浏览器都没找到闲鱼登录态（试过：{tried}）。"
+        f"请在任一浏览器里登录 https://www.goofish.com 后重试。"
+    )

--- a/src/goofish_cli/core/errors.py
+++ b/src/goofish_cli/core/errors.py
@@ -1,13 +1,23 @@
-"""统一异常体系。driver 层根据响应体 ret 或状态自动抛对应异常。"""
+"""统一异常体系。driver 层根据响应体 ret 或状态自动抛对应异常。
+
+退出码参照 sysexits.h（与 opencli 对齐）：
+- 1   GENERIC
+- 75  TEMPFAIL   —— RateLimitedError
+- 76  RISK       —— RiskControlError（项目特有，对应 RGV587 / punish）
+- 77  NOPERM     —— AuthRequiredError
+- 78  CONFIG     —— SignError
+- 79  NOINPUT    —— NotFoundError / EmptyResultError / BlockedError
+"""
 from __future__ import annotations
 
 
 class GoofishError(Exception):
     exit_code = 1
 
-    def __init__(self, message: str, *, raw: dict | None = None):
+    def __init__(self, message: str, *, raw: dict | None = None, hint: str | None = None):
         super().__init__(message)
         self.raw = raw
+        self.hint = hint
 
 
 class AuthRequiredError(GoofishError):
@@ -28,4 +38,14 @@ class RiskControlError(GoofishError):
 
 
 class NotFoundError(GoofishError):
+    exit_code = 79
+
+
+class EmptyResultError(GoofishError):
+    """查询无命中。对标 opencli EmptyResultError。"""
+    exit_code = 79
+
+
+class BlockedError(GoofishError):
+    """请求被拦截（验证码页 / 安全验证 / 异常访问）。对标 opencli 的 blocked 分支。"""
     exit_code = 79

--- a/src/goofish_cli/core/session.py
+++ b/src/goofish_cli/core/session.py
@@ -1,4 +1,12 @@
-"""cookie 加载 + requests.Session 管理 + token 提取。"""
+"""cookie 加载 + requests.Session 管理 + token 提取。
+
+登录态解析顺序（从低认知负荷到高）：
+1. cookies.json 存在且有效 → 直接用
+2. cookies.json 不存在 → 自动从本机 Chrome 抓一次（零感知 bootstrap）
+3. Chrome 也抓不到 → 抛 AuthRequiredError，附带明确的手动兜底提示
+
+环境变量 GOOFISH_NO_CHROME_BOOTSTRAP=1 可关闭自动抓 Chrome（CI 场景）。
+"""
 from __future__ import annotations
 
 import json
@@ -7,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import requests
+from loguru import logger
 
 from goofish_cli.core.errors import AuthRequiredError
 from goofish_cli.core.sign import generate_device_id
@@ -32,14 +41,13 @@ class Session:
         path = Path(os.path.expanduser(
             cookie_path or os.environ.get("GOOFISH_COOKIES_PATH") or DEFAULT_COOKIE_PATH
         ))
-        if not path.exists():
-            raise AuthRequiredError(
-                f"cookie 文件不存在：{path}。请先 `goofish auth login --from <path>` 导入。"
-            )
-        cookies = _load_cookies(path)
+
+        cookies = _load_or_bootstrap_cookies(path)
+
         if "unb" not in cookies or "_m_h5_tk" not in cookies:
             raise AuthRequiredError(
-                f"cookie 缺失 unb / _m_h5_tk，检查 {path} 是否完整（建议从 goofish.com 登录后再导一次）"
+                f"cookie 缺失 unb / _m_h5_tk，检查 {path} 是否完整（建议先在 Chrome 登录 "
+                f"https://www.goofish.com 后再试 `goofish auth login`）"
             )
         http = requests.Session()
         http.cookies.update(cookies)
@@ -54,6 +62,53 @@ class Session:
     def h5_token(self) -> str:
         raw = self.http.cookies.get("_m_h5_tk", "")
         return raw.split("_")[0] if raw else ""
+
+
+def _load_or_bootstrap_cookies(path: Path) -> dict[str, str]:
+    """先查本地 cookies.json；没有就从 Chrome 自动抓一次写入。"""
+    if path.exists():
+        return _load_cookies(path)
+
+    # 本地不存在，走自动 bootstrap（除非用户显式关闭）
+    if os.environ.get("GOOFISH_NO_CHROME_BOOTSTRAP") == "1":
+        raise AuthRequiredError(
+            f"cookie 文件不存在：{path}。\n"
+            f"请执行 `goofish auth login` 自动从 Chrome 导入，"
+            f"或 `goofish auth login --from <path>` 手动指定。"
+        )
+
+    try:
+        browser, cookies = _bootstrap_from_browser()
+    except Exception as e:  # noqa: BLE001 — 浏览器抽取失败就走友好兜底
+        logger.debug(f"浏览器自动导入失败：{e}")
+        raise AuthRequiredError(
+            f"cookie 文件不存在：{path}。\n"
+            f"自动从浏览器导入也失败了（{e}）。\n"
+            f"请在 Chrome / Edge / Brave 等任一浏览器里登录 https://www.goofish.com 后重试，"
+            f"或手动导出 JSON：`goofish auth login <path>`。"
+        ) from e
+
+    # bootstrap 成功 → 落盘一份，下次直接走缓存
+    write_cookies_json(path, cookies)
+    logger.info(f"已从 {browser} 自动导入登录态 → {path}")
+    return cookies
+
+
+def _bootstrap_from_browser() -> tuple[str, dict[str, str]]:
+    """单独封装一层，方便测试时 monkeypatch。"""
+    from goofish_cli.core.browser_cookie import extract_goofish_cookies
+    return extract_goofish_cookies(browser="auto")
+
+
+def write_cookies_json(path: Path, cookies: dict[str, str]) -> None:
+    """把 cookies dict 以 Chrome 扩展风格 JSON 数组落盘。供 auth login 复用。"""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(
+        [{"name": k, "value": v} for k, v in cookies.items()],
+        ensure_ascii=False,
+        indent=2,
+    ))
+    path.chmod(0o600)
 
 
 def _load_or_mint_device_id(unb: str) -> str:

--- a/tests/test_browser_cookie.py
+++ b/tests/test_browser_cookie.py
@@ -1,0 +1,144 @@
+"""browser_cookie 多浏览器 auto-detect 流程。
+
+核心场景：
+1. available_browsers 反射能枚举到已装浏览器
+2. 单浏览器模式：拿到 REQUIRED_KEYS → 返回；缺失 → 抛 BrowserCookieError
+3. auto 模式：第一个成功的就返回；全部失败则抛
+4. 域过滤：只保留阿里系 cookie，其他站点过滤
+"""
+from __future__ import annotations
+
+import http.cookiejar as cookiejar
+
+import pytest
+
+from goofish_cli.core import browser_cookie as bc
+
+
+def _make_cookie(name: str, value: str, domain: str) -> cookiejar.Cookie:
+    """造一个符合 CookieJar 迭代结果的 Cookie 对象。"""
+    return cookiejar.Cookie(
+        version=0, name=name, value=value,
+        port=None, port_specified=False,
+        domain=domain, domain_specified=True, domain_initial_dot=domain.startswith("."),
+        path="/", path_specified=True, secure=False,
+        expires=None, discard=False, comment=None, comment_url=None,
+        rest={}, rfc2109=False,
+    )
+
+
+def _fake_jar(*cookies):
+    jar = cookiejar.CookieJar()
+    for c in cookies:
+        jar.set_cookie(c)
+    return jar
+
+
+# ── 反射枚举 ─────────────────────────────────────────────────────────────
+
+def test_available_browsers_has_edge_and_chrome():
+    """browser_cookie3 升级时本测试可能需要刷新；
+    至少要有 chrome 和 edge——我们对用户承诺过支持这两个。"""
+    names = bc.available_browsers()
+    assert "chrome" in names
+    assert "edge" in names
+    # 不应该包括 load（它会尝试所有浏览器，和我们的 auto 重复）
+    assert "load" not in names
+
+
+# ── 指定单浏览器 ─────────────────────────────────────────────────────────
+
+def test_extract_single_browser_success(monkeypatch):
+    """edge 里抓到 unb/_m_h5_tk → 正常返回 (browser, cookies)。"""
+    jar = _fake_jar(
+        _make_cookie("unb", "2214350705775", ".taobao.com"),
+        _make_cookie("_m_h5_tk", "TOKEN_abc_123", ".taobao.com"),
+        _make_cookie("tracknick", "xy575986", ".goofish.com"),
+        # 非阿里系域的 cookie，必须被过滤
+        _make_cookie("sessionid", "other", ".example.com"),
+    )
+    import browser_cookie3 as bc3
+    monkeypatch.setattr(bc3, "edge", lambda domain_name: jar)
+
+    used, cookies = bc.extract_goofish_cookies(browser="edge")
+    assert used == "edge"
+    assert cookies["unb"] == "2214350705775"
+    assert cookies["_m_h5_tk"] == "TOKEN_abc_123"
+    assert cookies["tracknick"] == "xy575986"
+    assert "sessionid" not in cookies
+
+
+def test_extract_single_browser_missing_required_raises(monkeypatch):
+    """edge 里只拿到 tracknick，缺 unb/_m_h5_tk → BrowserCookieError。"""
+    jar = _fake_jar(_make_cookie("tracknick", "x", ".goofish.com"))
+    import browser_cookie3 as bc3
+    monkeypatch.setattr(bc3, "edge", lambda domain_name: jar)
+
+    # subprocess 也 mock 成无效，避免真启动子进程跑到用户真实浏览器
+    monkeypatch.setattr(bc, "_extract_via_subprocess", lambda _: None)
+
+    with pytest.raises(bc.BrowserCookieError) as ei:
+        bc.extract_goofish_cookies(browser="edge")
+    assert "edge" in str(ei.value)
+
+
+def test_extract_unknown_browser_raises(monkeypatch):
+    # subprocess 也屏蔽
+    monkeypatch.setattr(bc, "_extract_via_subprocess", lambda _: None)
+    with pytest.raises(bc.BrowserCookieError):
+        bc.extract_goofish_cookies(browser="nonexistent-browser")
+
+
+# ── auto 模式 ────────────────────────────────────────────────────────────
+
+def test_extract_auto_returns_first_success(monkeypatch):
+    """auto 模式：chrome 空、edge 有 → 返回 edge 的结果。"""
+    valid = {"unb": "U", "_m_h5_tk": "T_xxx_1", "tracknick": "nick"}
+
+    def fake_try(browser: str):
+        if browser == "edge":
+            return valid
+        return None
+
+    monkeypatch.setattr(bc, "_try_browser", fake_try)
+    # 反射结果固定，避免依赖环境
+    monkeypatch.setattr(bc, "available_browsers", lambda: ("chrome", "edge", "safari"))
+
+    used, cookies = bc.extract_goofish_cookies(browser="auto")
+    assert used == "edge"
+    assert cookies == valid
+
+
+def test_extract_auto_all_fail_raises(monkeypatch):
+    monkeypatch.setattr(bc, "_try_browser", lambda _: None)
+    monkeypatch.setattr(bc, "available_browsers", lambda: ("chrome", "edge"))
+
+    with pytest.raises(bc.BrowserCookieError) as ei:
+        bc.extract_goofish_cookies(browser="auto")
+    # 错误信息要告诉用户具体试过哪些
+    assert "chrome" in str(ei.value)
+    assert "edge" in str(ei.value)
+
+
+def test_extract_auto_empty_browser_list(monkeypatch):
+    monkeypatch.setattr(bc, "available_browsers", lambda: ())
+    with pytest.raises(bc.BrowserCookieError):
+        bc.extract_goofish_cookies(browser="auto")
+
+
+# ── 辅助函数 ──────────────────────────────────────────────────────────────
+
+def test_is_valid_requires_all_keys():
+    assert bc._is_valid({"unb": "U", "_m_h5_tk": "T"})
+    assert not bc._is_valid({"unb": "U"})
+    assert not bc._is_valid({"unb": "", "_m_h5_tk": "T"})  # 空字符串不算
+
+
+def test_jars_to_dict_filters_non_alibaba():
+    jar = _fake_jar(
+        _make_cookie("unb", "U", ".taobao.com"),
+        _make_cookie("sessionid", "bad", ".github.com"),
+        _make_cookie("foo", "bar", ".tmall.com"),
+    )
+    out = bc._jars_to_dict([jar])
+    assert out == {"unb": "U", "foo": "bar"}

--- a/tests/test_session_bootstrap.py
+++ b/tests/test_session_bootstrap.py
@@ -1,0 +1,119 @@
+"""Session.load 自动 bootstrap 行为。
+
+目标：验证零认知负荷路径——cookies.json 不存在时，自动从 Chrome 抓。
+所有真 Chrome 调用都 monkeypatch 掉。
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from goofish_cli.core import session as session_mod
+from goofish_cli.core.errors import AuthRequiredError
+
+
+@pytest.fixture
+def fake_cookies_path(tmp_path, monkeypatch):
+    """把 DEFAULT_COOKIE_PATH / DEVICE_CACHE_PATH 指到 tmp_path，
+    避免测试互相干扰、也避免踩到用户真实的 ~/.goofish-cli。"""
+    cookies = tmp_path / "cookies.json"
+    device = tmp_path / "device.json"
+    monkeypatch.setattr(session_mod, "DEFAULT_COOKIE_PATH", cookies)
+    monkeypatch.setattr(session_mod, "DEVICE_CACHE_PATH", device)
+    monkeypatch.delenv("GOOFISH_COOKIES_PATH", raising=False)
+    monkeypatch.delenv("GOOFISH_NO_CHROME_BOOTSTRAP", raising=False)
+    return cookies
+
+
+def test_load_uses_existing_cookies_json(fake_cookies_path, monkeypatch):
+    """cookies.json 已存在 → 不该触发 Chrome bootstrap。"""
+    fake_cookies_path.write_text(json.dumps([
+        {"name": "unb", "value": "U1"},
+        {"name": "_m_h5_tk", "value": "T_xxx_1"},
+        {"name": "tracknick", "value": "nick1"},
+    ]))
+
+    # bootstrap 被调用就失败
+    def fail(*_args, **_kwargs):
+        raise AssertionError("bootstrap 不该被触发")
+    monkeypatch.setattr(session_mod, "_bootstrap_from_browser", fail)
+
+    s = session_mod.Session.load()
+    assert s.unb == "U1"
+    assert s.tracknick == "nick1"
+    assert s.h5_token == "T"  # _m_h5_tk 取下划线前那一段
+
+
+def test_load_bootstraps_when_missing(fake_cookies_path, monkeypatch):
+    """cookies.json 不存在 → 自动从浏览器抓 → 写盘，下次直接读。"""
+    fake = {"unb": "U2", "_m_h5_tk": "T_99_1", "tracknick": "nick2"}
+    called = {"n": 0}
+
+    def fake_bootstrap():
+        called["n"] += 1
+        return "edge", fake
+    monkeypatch.setattr(session_mod, "_bootstrap_from_browser", fake_bootstrap)
+
+    s = session_mod.Session.load()
+    assert s.unb == "U2"
+    assert called["n"] == 1
+    # 写盘了
+    assert fake_cookies_path.exists()
+    data = json.loads(fake_cookies_path.read_text())
+    assert {"name": "unb", "value": "U2"} in data
+    # 文件权限 0o600
+    assert (fake_cookies_path.stat().st_mode & 0o777) == 0o600
+
+    # 第二次 load 应命中缓存，不再调 bootstrap
+    s2 = session_mod.Session.load()
+    assert s2.unb == "U2"
+    assert called["n"] == 1, "第二次不该再调 bootstrap"
+
+
+def test_load_falls_back_to_auth_error_when_bootstrap_fails(fake_cookies_path, monkeypatch):
+    """浏览器抓失败 → AuthRequiredError 并给出手动兜底提示。"""
+    def boom():
+        raise RuntimeError("all browsers failed")
+    monkeypatch.setattr(session_mod, "_bootstrap_from_browser", boom)
+
+    with pytest.raises(AuthRequiredError) as ei:
+        session_mod.Session.load()
+    msg = str(ei.value)
+    # 错误必须指向手动兜底路径
+    assert "auth login" in msg
+    assert "all browsers failed" in msg
+
+
+def test_load_skips_bootstrap_when_env_disabled(fake_cookies_path, monkeypatch):
+    """GOOFISH_NO_CHROME_BOOTSTRAP=1 → 不自动探测浏览器，直接报错。CI 场景需要这个开关。"""
+    monkeypatch.setenv("GOOFISH_NO_CHROME_BOOTSTRAP", "1")
+
+    def fail(*_a, **_k):
+        raise AssertionError("bootstrap 被触发了")
+    monkeypatch.setattr(session_mod, "_bootstrap_from_browser", fail)
+
+    with pytest.raises(AuthRequiredError) as ei:
+        session_mod.Session.load()
+    assert "cookie 文件不存在" in str(ei.value)
+
+
+def test_load_raises_when_bootstrapped_cookies_missing_keys(fake_cookies_path, monkeypatch):
+    """bootstrap 回来的 cookie 不带 unb/_m_h5_tk → 依旧报错，
+    避免把半残 cookie 落盘造成后续命令反复失败。"""
+    monkeypatch.setattr(
+        session_mod, "_bootstrap_from_browser",
+        lambda: ("edge", {"tracknick": "nick_only"}),
+    )
+
+    with pytest.raises(AuthRequiredError):
+        session_mod.Session.load()
+
+
+def test_write_cookies_json_format(tmp_path):
+    """write_cookies_json 应写 Chrome 扩展风格的 list。auth login 和 Session 都用同一个。"""
+    target = tmp_path / "out.json"
+    session_mod.write_cookies_json(target, {"a": "1", "b": "2"})
+    data = json.loads(target.read_text())
+    assert data == [{"name": "a", "value": "1"}, {"name": "b", "value": "2"}]
+    assert (target.stat().st_mode & 0o777) == 0o600


### PR DESCRIPTION
## Summary

首次运行任意 `goofish` 命令时，自动从已登录的浏览器（Chrome/Edge/Brave/Firefox/Safari 等 13 种）抽取闲鱼 cookie 并落盘——用户不再需要手动从 DevTools 导出 JSON。

**分层兜底**（从零认知负荷到高）：

1. `cookies.json` 存在 → 直接用（零感知）
2. 不存在 → auto-detect 所有已装浏览器，`FIRST_COMPLETED` 返回（零感知）
3. 所有浏览器都没拿到 → `AuthRequiredError` 给出手动兜底路径（`<path>` / `--raw` / `--browser <name>`）

**设计参考**：对标 [opencli](https://github.com/jackwener/opencli) 的 `Strategy.COOKIE`（复用浏览器登录态）；auto-detect 并发模式借鉴 [xiaohongshu-cli](https://github.com/jackwener/xiaohongshu-cli) 的 `browser_cookie3` + `ThreadPoolExecutor` 实现。

## Changes

- `core/browser_cookie.py`（新增）：基于 `browser_cookie3` 的 auto-detect，`ThreadPoolExecutor(max_workers=4)` 并发探测，双路兜底 in-process → subprocess
- `core/session.py`：`Session.load` 加 auto-bootstrap；提取 `write_cookies_json` 为公共工具；新增 `GOOFISH_NO_CHROME_BOOTSTRAP=1` 环境变量（CI 场景关闭自动探测）
- `commands/auth/login.py`：`goofish auth login` 默认走 auto；保留 `<path>` / `--raw` / `--browser <name>` 降级路径；错误提示里列出所有支持的浏览器
- `core/errors.py`：新增 `EmptyResultError` / `BlockedError`，对标 opencli 错误体系（给未来页面级命令预留）
- `pyproject.toml`：添加 `browser-cookie3>=0.20` 依赖

## 支持的浏览器

`arc / brave / chrome / chromium / edge / firefox / librewolf / lynx / opera / opera_gx / safari / vivaldi / w3m`（由 `browser_cookie3` 提供）

## Test plan

- [x] 48 个单元测试（新增 15 个：9 个 `test_browser_cookie` + 6 个 `test_session_bootstrap`），ruff 零告警
- [x] 真实验证 Edge 拉取：`goofish auth login` 零参数 → 22 个 cookie（含关键 `cookie2` / `sgcookie`），`auth status` 返回 `valid: true`
- [x] 真实验证错误兜底：`--browser chrome`（本机未登录闲鱼）正确抛 `AuthRequiredError` 并列出所有降级方案
- [x] 真实验证向后兼容：原有 `cookies.json` 存在时不触发 bootstrap，现有命令链路无回归

## 约束

- 不影响现有 mtop HTTP-only 架构，只是把"登录态获取"从手动改为自动
- `GOOFISH_NO_CHROME_BOOTSTRAP=1` 可在 CI 环境关闭自动探测（避免 Keychain 弹框）