### PR TITLE
fix(auth): 消化 Copilot review 反馈 — 边界/语义/性能

### DIFF
--- a/src/goofish_cli/commands/auth/login.py
+++ b/src/goofish_cli/commands/auth/login.py
@@ -42,6 +42,13 @@ def login(
     target = DEFAULT_COOKIE_PATH
 
     if source is None:
+        if raw:
+            # --raw 要求紧跟 cookie 字符串；如果没传 source，说明用户漏了参数——
+            # 不能静默走浏览器 auto-detect，否则 --raw 被吞，用户会困惑。
+            raise ValueError(
+                "--raw 需要配合 cookie 字符串使用，如："
+                "goofish auth login 'unb=...; _m_h5_tk=...' --raw"
+            )
         cookies, source_label = _pull_from_browser(browser)
     elif raw:
         cookies = _parse_raw(source)

--- a/src/goofish_cli/core/browser_cookie.py
+++ b/src/goofish_cli/core/browser_cookie.py
@@ -29,6 +29,13 @@ from loguru import logger
 # 我们分别拉一遍后合并。
 GOOFISH_DOMAINS = ("goofish.com", "taobao.com")
 
+# cookie 入库前的域名白名单。in-process 和 subprocess 两条路径都用这个常量，
+# 保证两条路径筛出的字段集一致（避免漂移导致同一浏览器两次抽取结果不同）。
+ALLOWED_HOSTS = (
+    "goofish.com", "taobao.com", "tmall.com",
+    "alibaba.com", "alicdn.com", "aliyun.com", "mmstat.com",
+)
+
 # 至少要拿到这些字段才算"登录态有效"
 REQUIRED_KEYS = ("unb", "_m_h5_tk")
 
@@ -75,12 +82,13 @@ def _get_loader(browser: str):
 # ── 单个浏览器的 in-process / subprocess 双路 ────────────────────────────
 
 def _extract_in_process(browser: str) -> dict[str, str] | None:
-    """直接 import browser_cookie3 调 loader。"""
-    try:
-        loader = _get_loader(browser)
-    except (ImportError, BrowserCookieError) as e:
-        logger.trace(f"{browser} in-process loader 获取失败：{e}")
-        return None
+    """直接 import browser_cookie3 调 loader。
+
+    注意：对 `BrowserCookieError`（未知浏览器名）会直接 re-raise，让调用方
+    区分"浏览器不认识"和"浏览器没登录态"两种情况——不然用户传 --browser foobar
+    会得到误导性的"没找到有效登录态"。
+    """
+    loader = _get_loader(browser)  # 未知浏览器 → re-raise
 
     try:
         jars = [loader(domain_name=domain) for domain in GOOFISH_DOMAINS]
@@ -93,7 +101,11 @@ def _extract_in_process(browser: str) -> dict[str, str] | None:
 
 def _extract_via_subprocess(browser: str) -> dict[str, str] | None:
     """fork 子进程跑 browser_cookie3。macOS Keychain 对主进程和子进程的
-    授权作用域有时不一致，子进程兜底能救一些 Edge Case（也是 xhs-cli 的做法）。"""
+    授权作用域有时不一致，子进程兜底能救一些 Edge Case（也是 xhs-cli 的做法）。
+
+    allowed_hosts 通过 argv 传进子进程，和 _jars_to_dict 用同一个常量，避免
+    两条路径筛出的字段集漂移。
+    """
     script = '''
 import json, sys
 try:
@@ -101,8 +113,9 @@ try:
 except ImportError:
     print(json.dumps({"error": "browser-cookie3-not-installed"})); sys.exit(0)
 
-browser = sys.argv[1]
-domains = sys.argv[2].split(",")
+browser, domains_csv, hosts_csv = sys.argv[1], sys.argv[2], sys.argv[3]
+domains = domains_csv.split(",")
+hosts = hosts_csv.split(",")
 loader = getattr(bc3, browser, None)
 if not loader or not callable(loader):
     print(json.dumps({"error": f"unknown-browser:{browser}"})); sys.exit(0)
@@ -112,7 +125,7 @@ for d in domains:
     try:
         for c in loader(domain_name=d):
             host = (c.domain or "").lstrip(".")
-            if any(h in host for h in ("goofish.com", "taobao.com", "tmall.com", "alibaba.com", "alicdn.com", "aliyun.com")):
+            if any(h in host for h in hosts):
                 out[c.name] = c.value
     except Exception as e:
         print(json.dumps({"error": f"extract-fail:{e}"})); sys.exit(0)
@@ -120,7 +133,12 @@ print(json.dumps({"cookies": out}))
 '''
     try:
         result = subprocess.run(
-            [sys.executable, "-c", script, browser, ",".join(GOOFISH_DOMAINS)],
+            [
+                sys.executable, "-c", script,
+                browser,
+                ",".join(GOOFISH_DOMAINS),
+                ",".join(ALLOWED_HOSTS),
+            ],
             capture_output=True,
             text=True,
             timeout=15,
@@ -148,15 +166,11 @@ print(json.dumps({"cookies": out}))
 
 def _jars_to_dict(jars: list[Any]) -> dict[str, str]:
     """从多个 CookieJar 合并筛出阿里系域 cookie。"""
-    allowed_hosts = (
-        "goofish.com", "taobao.com", "tmall.com",
-        "alibaba.com", "alicdn.com", "aliyun.com", "mmstat.com",
-    )
     out: dict[str, str] = {}
     for jar in jars:
         for cookie in jar:
             host = (cookie.domain or "").lstrip(".")
-            if not any(h in host for h in allowed_hosts):
+            if not any(h in host for h in ALLOWED_HOSTS):
                 continue
             # 同名后写覆盖前 —— 这里没法判优先级，实测取到 unb/_m_h5_tk 都 OK
             out[cookie.name] = cookie.value
@@ -164,8 +178,16 @@ def _jars_to_dict(jars: list[Any]) -> dict[str, str]:
 
 
 def _try_browser(browser: str) -> dict[str, str] | None:
-    """顺序走 in-process → subprocess。任一路径拿到 REQUIRED_KEYS 就返回。"""
-    cookies = _extract_in_process(browser)
+    """顺序走 in-process → subprocess。任一路径拿到 REQUIRED_KEYS 就返回。
+
+    包住 _extract_in_process 的 BrowserCookieError —— auto 模式下反射出的
+    名字肯定存在，不会触发；指定 browser 模式由 extract_goofish_cookies
+    先校验，也不会到这。兜底：万一进来了就当成"该浏览器没有"。
+    """
+    try:
+        cookies = _extract_in_process(browser)
+    except BrowserCookieError:
+        cookies = None
     if cookies and _is_valid(cookies):
         return cookies
     cookies = _extract_via_subprocess(browser)
@@ -194,8 +216,11 @@ def extract_goofish_cookies(
       - 具体浏览器名（chrome / edge / brave / safari / firefox / ...）
 
     REQUIRED_KEYS 缺失 → 抛 BrowserCookieError，由上层转成 AuthRequiredError。
+    未知浏览器名 → 直接抛 BrowserCookieError（不当成"没登录态"误导用户）。
     """
     if browser != "auto":
+        # 先做一次名字校验，让"浏览器名不对"和"没登录态"报错分开
+        _get_loader(browser)
         cookies = _try_browser(browser)
         if cookies:
             return browser, cookies
@@ -211,8 +236,12 @@ def extract_goofish_cookies(
             "请确认安装：`pip install browser-cookie3`。"
         )
 
-    # 并发试所有浏览器，FIRST_COMPLETED 拿到就 cancel 其他
-    with ThreadPoolExecutor(max_workers=min(max_workers, len(browsers))) as pool:
+    # 并发试所有浏览器，拿到第一个成功的立刻返回。
+    # 不用 `with ThreadPoolExecutor(...) as pool` —— 退出 with 时会 shutdown(wait=True)，
+    # 让 return 等所有浏览器跑完（即使 cancel 过），违背 FIRST_COMPLETED 的初衷。
+    # 手动管理 + cancel_futures=True 才能真正快速返回。
+    pool = ThreadPoolExecutor(max_workers=min(max_workers, len(browsers)))
+    try:
         future_to_browser = {pool.submit(_try_browser, b): b for b in browsers}
         pending = set(future_to_browser)
         while pending:
@@ -220,10 +249,11 @@ def extract_goofish_cookies(
             for fut in done:
                 cookies = fut.result()
                 if cookies:
-                    # 拿到就返回；其它线程让它们自己跑完（cancel 对正在执行的 future 无效）
-                    for p in pending:
-                        p.cancel()
+                    pool.shutdown(wait=False, cancel_futures=True)
                     return future_to_browser[fut], cookies
+    finally:
+        # 无论成功与否，确保 pool 不会让调用者 hang 住
+        pool.shutdown(wait=False, cancel_futures=True)
 
     tried = ", ".join(browsers)
     raise BrowserCookieError(

--- a/src/goofish_cli/core/session.py
+++ b/src/goofish_cli/core/session.py
@@ -2,10 +2,11 @@
 
 登录态解析顺序（从低认知负荷到高）：
 1. cookies.json 存在且有效 → 直接用
-2. cookies.json 不存在 → 自动从本机 Chrome 抓一次（零感知 bootstrap）
-3. Chrome 也抓不到 → 抛 AuthRequiredError，附带明确的手动兜底提示
+2. cookies.json 不存在 → 从本机浏览器自动导入（auto-detect Chrome/Edge/
+   Brave/Firefox/Safari 等，并发探测，哪个先成功用哪个）
+3. 浏览器也抓不到 → 抛 AuthRequiredError，附带明确的手动兜底提示
 
-环境变量 GOOFISH_NO_CHROME_BOOTSTRAP=1 可关闭自动抓 Chrome（CI 场景）。
+环境变量 GOOFISH_NO_CHROME_BOOTSTRAP=1 可关闭自动探测（CI 场景）。
 """
 from __future__ import annotations
 
@@ -46,7 +47,7 @@ class Session:
 
         if "unb" not in cookies or "_m_h5_tk" not in cookies:
             raise AuthRequiredError(
-                f"cookie 缺失 unb / _m_h5_tk，检查 {path} 是否完整（建议先在 Chrome 登录 "
+                f"cookie 缺失 unb / _m_h5_tk，检查 {path} 是否完整（建议先在浏览器登录 "
                 f"https://www.goofish.com 后再试 `goofish auth login`）"
             )
         http = requests.Session()
@@ -65,7 +66,7 @@ class Session:
 
 
 def _load_or_bootstrap_cookies(path: Path) -> dict[str, str]:
-    """先查本地 cookies.json；没有就从 Chrome 自动抓一次写入。"""
+    """先查本地 cookies.json；没有就从本机浏览器自动导入一次写盘。"""
     if path.exists():
         return _load_cookies(path)
 
@@ -73,8 +74,8 @@ def _load_or_bootstrap_cookies(path: Path) -> dict[str, str]:
     if os.environ.get("GOOFISH_NO_CHROME_BOOTSTRAP") == "1":
         raise AuthRequiredError(
             f"cookie 文件不存在：{path}。\n"
-            f"请执行 `goofish auth login` 自动从 Chrome 导入，"
-            f"或 `goofish auth login --from <path>` 手动指定。"
+            f"请执行 `goofish auth login` 从本机浏览器自动导入，"
+            f"或 `goofish auth login <path>` 手动指定。"
         )
 
     try:
@@ -88,7 +89,14 @@ def _load_or_bootstrap_cookies(path: Path) -> dict[str, str]:
             f"或手动导出 JSON：`goofish auth login <path>`。"
         ) from e
 
-    # bootstrap 成功 → 落盘一份，下次直接走缓存
+    # 写盘前最后一道校验：bootstrap 回来的 cookies 必须含 REQUIRED_KEYS，
+    # 否则坚决不落盘——避免半残 cookie 污染后续每次 Session.load。
+    if "unb" not in cookies or "_m_h5_tk" not in cookies:
+        raise AuthRequiredError(
+            f"已从 {browser} 拿到 cookie，但缺 unb / _m_h5_tk 关键字段，"
+            f"未写入 {path}。请在 {browser} 里重新登录 https://www.goofish.com 后重试。"
+        )
+
     write_cookies_json(path, cookies)
     logger.info(f"已从 {browser} 自动导入登录态 → {path}")
     return cookies

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -1,0 +1,74 @@
+"""auth login 命令的参数组合与报错语义。"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from goofish_cli.commands.auth import login as login_mod
+from goofish_cli.core import session as session_mod
+
+
+@pytest.fixture
+def fake_target(tmp_path, monkeypatch):
+    """把写盘目标指到 tmp_path，避免踩到用户真实 ~/.goofish-cli/cookies.json。"""
+    target = tmp_path / "cookies.json"
+    monkeypatch.setattr(login_mod, "DEFAULT_COOKIE_PATH", target)
+    monkeypatch.setattr(session_mod, "DEFAULT_COOKIE_PATH", target)
+    monkeypatch.setattr(session_mod, "DEVICE_CACHE_PATH", tmp_path / "device.json")
+    return target
+
+
+def test_raw_without_source_raises(fake_target, monkeypatch):
+    """goofish auth login --raw（没传 cookie 字符串）→ 必须报参数错，
+    不能静默走浏览器 auto——否则 --raw 标志被吞，用户会困惑为什么没生效。"""
+    # bootstrap 被调就失败（证明没走 auto 分支）
+    def boom(*_args, **_kwargs):
+        raise AssertionError("不该触发浏览器 auto")
+    monkeypatch.setattr(login_mod, "_pull_from_browser", boom)
+
+    with pytest.raises(ValueError) as ei:
+        login_mod.login(source=None, raw=True)
+    assert "--raw" in str(ei.value)
+
+
+def test_no_args_goes_to_browser_auto(fake_target, monkeypatch):
+    """goofish auth login 无参数 → 走浏览器 auto-detect。"""
+    fake = {"unb": "U", "_m_h5_tk": "T_xxx_1", "tracknick": "n"}
+    monkeypatch.setattr(login_mod, "_pull_from_browser", lambda b: (fake, f"browser:{b}"))
+
+    out = login_mod.login()
+    assert out["source"] == "browser:auto"
+    assert out["unb"] == "U"
+    assert fake_target.exists()
+
+
+def test_raw_with_source_parses(fake_target, monkeypatch):
+    """--raw 有 cookie 字符串 → 正确解析，不走浏览器。"""
+    def boom(*_args, **_kwargs):
+        raise AssertionError("不该触发浏览器 auto")
+    monkeypatch.setattr(login_mod, "_pull_from_browser", boom)
+
+    out = login_mod.login(
+        source="unb=U; _m_h5_tk=T_x_1; tracknick=n",
+        raw=True,
+    )
+    assert out["source"] == "raw"
+    assert out["unb"] == "U"
+
+
+def test_file_path_import(fake_target, tmp_path, monkeypatch):
+    """位置参数 <path> → 从 JSON 文件导入。"""
+    src = tmp_path / "src.json"
+    src.write_text(json.dumps([
+        {"name": "unb", "value": "U"},
+        {"name": "_m_h5_tk", "value": "T_x_1"},
+    ]))
+
+    def boom(*_args, **_kwargs):
+        raise AssertionError("不该触发浏览器 auto")
+    monkeypatch.setattr(login_mod, "_pull_from_browser", boom)
+
+    out = login_mod.login(source=str(src))
+    assert out["source"].startswith("file:")
+    assert out["unb"] == "U"

--- a/tests/test_browser_cookie.py
+++ b/tests/test_browser_cookie.py
@@ -82,11 +82,31 @@ def test_extract_single_browser_missing_required_raises(monkeypatch):
     assert "edge" in str(ei.value)
 
 
-def test_extract_unknown_browser_raises(monkeypatch):
-    # subprocess 也屏蔽
+def test_extract_unknown_browser_raises_distinct_error(monkeypatch):
+    """未知浏览器名 vs 浏览器没登录态 —— 报错消息必须区分开，否则用户无法排障。
+
+    - 未知浏览器：消息应含"不认识"/"支持列表"（来自 _get_loader）
+    - 没登录态：消息应含"没找到有效的闲鱼登录态"
+    """
+    # 避免 subprocess 真跑
     monkeypatch.setattr(bc, "_extract_via_subprocess", lambda _: None)
-    with pytest.raises(bc.BrowserCookieError):
+
+    with pytest.raises(bc.BrowserCookieError) as ei:
         bc.extract_goofish_cookies(browser="nonexistent-browser")
+    msg = str(ei.value)
+    assert "不认识" in msg or "支持列表" in msg, f"未知浏览器报错消息没区分：{msg}"
+
+
+def test_subprocess_and_in_process_share_allowed_hosts():
+    """in-process 和 subprocess 两条路径必须共用同一个 ALLOWED_HOSTS 常量，
+    避免两条路径筛出的字段集漂移——Copilot 指出过 mmstat.com 两边不一致。"""
+    # 确保常量存在且非空
+    assert bc.ALLOWED_HOSTS, "ALLOWED_HOSTS 不能为空"
+    # subprocess 脚本通过 argv 传 hosts —— 反证两条路径没各自 hardcode 一份
+    import inspect
+    src = inspect.getsource(bc._extract_via_subprocess)
+    assert "hosts_csv" in src, "subprocess 脚本没从 argv 读 hosts，可能又 hardcode 了"
+    assert 'ALLOWED_HOSTS' in src, "subprocess 启动参数里没引用 ALLOWED_HOSTS 常量"
 
 
 # ── auto 模式 ────────────────────────────────────────────────────────────

--- a/tests/test_session_bootstrap.py
+++ b/tests/test_session_bootstrap.py
@@ -100,14 +100,32 @@ def test_load_skips_bootstrap_when_env_disabled(fake_cookies_path, monkeypatch):
 
 def test_load_raises_when_bootstrapped_cookies_missing_keys(fake_cookies_path, monkeypatch):
     """bootstrap 回来的 cookie 不带 unb/_m_h5_tk → 依旧报错，
-    避免把半残 cookie 落盘造成后续命令反复失败。"""
+    且坚决不落盘——避免半残 cookie 污染后续每次 Session.load。"""
     monkeypatch.setattr(
         session_mod, "_bootstrap_from_browser",
         lambda: ("edge", {"tracknick": "nick_only"}),
     )
 
+    # 前置：确保出发前文件不存在（fixture 就是这样，但显式断言更稳）
+    assert not fake_cookies_path.exists()
+
     with pytest.raises(AuthRequiredError):
         session_mod.Session.load()
+
+    # 关键：失败不落盘。锁住回归——以前实现是先写再校验，半残 cookie 会污染磁盘。
+    assert not fake_cookies_path.exists()
+
+
+def test_load_raises_when_bootstrap_fail_does_not_write(fake_cookies_path, monkeypatch):
+    """bootstrap 整体抛异常时同样不能落盘。补漏——确保错误路径两种都安全。"""
+    def boom():
+        raise RuntimeError("keychain denied")
+    monkeypatch.setattr(session_mod, "_bootstrap_from_browser", boom)
+
+    assert not fake_cookies_path.exists()
+    with pytest.raises(AuthRequiredError):
+        session_mod.Session.load()
+    assert not fake_cookies_path.exists()
 
 
 def test_write_cookies_json_format(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -43,6 +43,21 @@ wheels = [
 ]
 
 [[package]]
+name = "browser-cookie3"
+version = "0.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jeepney", marker = "'bsd' in sys_platform or sys_platform == 'linux'" },
+    { name = "lz4" },
+    { name = "pycryptodomex" },
+    { name = "shadowcopy", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e1/652adea0ce25948e613ef78294c8ceaf4b32844aae00680d3a1712dde444/browser_cookie3-0.20.1.tar.gz", hash = "sha256:6d8d0744bf42a5327c951bdbcf77741db3455b8b4e840e18bab266d598368a12", size = 22665, upload-time = "2024-12-20T00:31:30.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/57/2a716f4ecf6c50b2dbe27439507c480bb7ca5725edef82349ecdcfcdd084/browser_cookie3-0.20.1-py3-none-any.whl", hash = "sha256:4b38bf669d386250733c8339f0036e1cf09c3d8e4d326fd507b9afb84def13d6", size = 17229, upload-time = "2025-01-04T14:46:14.753Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -295,6 +310,7 @@ name = "goofish-cli"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "browser-cookie3" },
     { name = "loguru" },
     { name = "mcp" },
     { name = "pydantic" },
@@ -317,6 +333,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "browser-cookie3", specifier = ">=0.20" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "mcp", specifier = ">=1.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
@@ -396,6 +413,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -509,6 +535,54 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "lz4"
+version = "4.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/5b/6edcd23319d9e28b1bedf32768c3d1fd56eed8223960a2c47dacd2cec2af/lz4-4.4.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d6da84a26b3aa5da13a62e4b89ab36a396e9327de8cd48b436a3467077f8ccd4", size = 207391, upload-time = "2025-11-03T13:01:36.644Z" },
+    { url = "https://files.pythonhosted.org/packages/34/36/5f9b772e85b3d5769367a79973b8030afad0d6b724444083bad09becd66f/lz4-4.4.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:61d0ee03e6c616f4a8b69987d03d514e8896c8b1b7cc7598ad029e5c6aedfd43", size = 207146, upload-time = "2025-11-03T13:01:37.928Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f4/f66da5647c0d72592081a37c8775feacc3d14d2625bbdaabd6307c274565/lz4-4.4.5-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:33dd86cea8375d8e5dd001e41f321d0a4b1eb7985f39be1b6a4f466cd480b8a7", size = 1292623, upload-time = "2025-11-03T13:01:39.341Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fc/5df0f17467cdda0cad464a9197a447027879197761b55faad7ca29c29a04/lz4-4.4.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:609a69c68e7cfcfa9d894dc06be13f2e00761485b62df4e2472f1b66f7b405fb", size = 1279982, upload-time = "2025-11-03T13:01:40.816Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3b/b55cb577aa148ed4e383e9700c36f70b651cd434e1c07568f0a86c9d5fbb/lz4-4.4.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:75419bb1a559af00250b8f1360d508444e80ed4b26d9d40ec5b09fe7875cb989", size = 1368674, upload-time = "2025-11-03T13:01:42.118Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/31/e97e8c74c59ea479598e5c55cbe0b1334f03ee74ca97726e872944ed42df/lz4-4.4.5-cp311-cp311-win32.whl", hash = "sha256:12233624f1bc2cebc414f9efb3113a03e89acce3ab6f72035577bc61b270d24d", size = 88168, upload-time = "2025-11-03T13:01:43.282Z" },
+    { url = "https://files.pythonhosted.org/packages/18/47/715865a6c7071f417bef9b57c8644f29cb7a55b77742bd5d93a609274e7e/lz4-4.4.5-cp311-cp311-win_amd64.whl", hash = "sha256:8a842ead8ca7c0ee2f396ca5d878c4c40439a527ebad2b996b0444f0074ed004", size = 99491, upload-time = "2025-11-03T13:01:44.167Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e7/ac120c2ca8caec5c945e6356ada2aa5cfabd83a01e3170f264a5c42c8231/lz4-4.4.5-cp311-cp311-win_arm64.whl", hash = "sha256:83bc23ef65b6ae44f3287c38cbf82c269e2e96a26e560aa551735883388dcc4b", size = 91271, upload-time = "2025-11-03T13:01:45.016Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/016e4f6de37d806f7cc8f13add0a46c9a7cfc41a5ddc2bc831d7954cf1ce/lz4-4.4.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:df5aa4cead2044bab83e0ebae56e0944cc7fcc1505c7787e9e1057d6d549897e", size = 207163, upload-time = "2025-11-03T13:01:45.895Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/df/0fadac6e5bd31b6f34a1a8dbd4db6a7606e70715387c27368586455b7fc9/lz4-4.4.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d0bf51e7745484d2092b3a51ae6eb58c3bd3ce0300cf2b2c14f76c536d5697a", size = 207150, upload-time = "2025-11-03T13:01:47.205Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/17/34e36cc49bb16ca73fb57fbd4c5eaa61760c6b64bce91fcb4e0f4a97f852/lz4-4.4.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7b62f94b523c251cf32aa4ab555f14d39bd1a9df385b72443fd76d7c7fb051f5", size = 1292045, upload-time = "2025-11-03T13:01:48.667Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1c/b1d8e3741e9fc89ed3b5f7ef5f22586c07ed6bb04e8343c2e98f0fa7ff04/lz4-4.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c3ea562c3af274264444819ae9b14dbbf1ab070aff214a05e97db6896c7597e", size = 1279546, upload-time = "2025-11-03T13:01:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/e3867222474f6c1b76e89f3bd914595af69f55bf2c1866e984c548afdc15/lz4-4.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24092635f47538b392c4eaeff14c7270d2c8e806bf4be2a6446a378591c5e69e", size = 1368249, upload-time = "2025-11-03T13:01:51.273Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e7/d667d337367686311c38b580d1ca3d5a23a6617e129f26becd4f5dc458df/lz4-4.4.5-cp312-cp312-win32.whl", hash = "sha256:214e37cfe270948ea7eb777229e211c601a3e0875541c1035ab408fbceaddf50", size = 88189, upload-time = "2025-11-03T13:01:52.605Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/0b/a54cd7406995ab097fceb907c7eb13a6ddd49e0b231e448f1a81a50af65c/lz4-4.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:713a777de88a73425cf08eb11f742cd2c98628e79a8673d6a52e3c5f0c116f33", size = 99497, upload-time = "2025-11-03T13:01:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7e/dc28a952e4bfa32ca16fa2eb026e7a6ce5d1411fcd5986cd08c74ec187b9/lz4-4.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:a88cbb729cc333334ccfb52f070463c21560fca63afcf636a9f160a55fac3301", size = 91279, upload-time = "2025-11-03T13:01:54.419Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/46/08fd8ef19b782f301d56a9ccfd7dafec5fd4fc1a9f017cf22a1accb585d7/lz4-4.4.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6bb05416444fafea170b07181bc70640975ecc2a8c92b3b658c554119519716c", size = 207171, upload-time = "2025-11-03T13:01:56.595Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3f/ea3334e59de30871d773963997ecdba96c4584c5f8007fd83cfc8f1ee935/lz4-4.4.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b424df1076e40d4e884cfcc4c77d815368b7fb9ebcd7e634f937725cd9a8a72a", size = 207163, upload-time = "2025-11-03T13:01:57.721Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7b/7b3a2a0feb998969f4793c650bb16eff5b06e80d1f7bff867feb332f2af2/lz4-4.4.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:216ca0c6c90719731c64f41cfbd6f27a736d7e50a10b70fad2a9c9b262ec923d", size = 1292136, upload-time = "2025-11-03T13:02:00.375Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d1/f1d259352227bb1c185288dd694121ea303e43404aa77560b879c90e7073/lz4-4.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:533298d208b58b651662dd972f52d807d48915176e5b032fb4f8c3b6f5fe535c", size = 1279639, upload-time = "2025-11-03T13:02:01.649Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/fb/ba9256c48266a09012ed1d9b0253b9aa4fe9cdff094f8febf5b26a4aa2a2/lz4-4.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:451039b609b9a88a934800b5fc6ee401c89ad9c175abf2f4d9f8b2e4ef1afc64", size = 1368257, upload-time = "2025-11-03T13:02:03.35Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6d/dee32a9430c8b0e01bbb4537573cabd00555827f1a0a42d4e24ca803935c/lz4-4.4.5-cp313-cp313-win32.whl", hash = "sha256:a5f197ffa6fc0e93207b0af71b302e0a2f6f29982e5de0fbda61606dd3a55832", size = 88191, upload-time = "2025-11-03T13:02:04.406Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e0/f06028aea741bbecb2a7e9648f4643235279a770c7ffaf70bd4860c73661/lz4-4.4.5-cp313-cp313-win_amd64.whl", hash = "sha256:da68497f78953017deb20edff0dba95641cc86e7423dfadf7c0264e1ac60dc22", size = 99502, upload-time = "2025-11-03T13:02:05.886Z" },
+    { url = "https://files.pythonhosted.org/packages/61/72/5bef44afb303e56078676b9f2486f13173a3c1e7f17eaac1793538174817/lz4-4.4.5-cp313-cp313-win_arm64.whl", hash = "sha256:c1cfa663468a189dab510ab231aad030970593f997746d7a324d40104db0d0a9", size = 91285, upload-time = "2025-11-03T13:02:06.77Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/6a5c2952971af73f15ed4ebfdd69774b454bd0dc905b289082ca8664fba1/lz4-4.4.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67531da3b62f49c939e09d56492baf397175ff39926d0bd5bd2d191ac2bff95f", size = 207348, upload-time = "2025-11-03T13:02:08.117Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d7/fd62cbdbdccc35341e83aabdb3f6d5c19be2687d0a4eaf6457ddf53bba64/lz4-4.4.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a1acbbba9edbcbb982bc2cac5e7108f0f553aebac1040fbec67a011a45afa1ba", size = 207340, upload-time = "2025-11-03T13:02:09.152Z" },
+    { url = "https://files.pythonhosted.org/packages/77/69/225ffadaacb4b0e0eb5fd263541edd938f16cd21fe1eae3cd6d5b6a259dc/lz4-4.4.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a482eecc0b7829c89b498fda883dbd50e98153a116de612ee7c111c8bcf82d1d", size = 1293398, upload-time = "2025-11-03T13:02:10.272Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9e/2ce59ba4a21ea5dc43460cba6f34584e187328019abc0e66698f2b66c881/lz4-4.4.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e099ddfaa88f59dd8d36c8a3c66bd982b4984edf127eb18e30bb49bdba68ce67", size = 1281209, upload-time = "2025-11-03T13:02:12.091Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4f/4d946bd1624ec229b386a3bc8e7a85fa9a963d67d0a62043f0af0978d3da/lz4-4.4.5-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2af2897333b421360fdcce895c6f6281dc3fab018d19d341cf64d043fc8d90d", size = 1369406, upload-time = "2025-11-03T13:02:13.683Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/d429ba4720a9064722698b4b754fb93e42e625f1318b8fe834086c7c783b/lz4-4.4.5-cp313-cp313t-win32.whl", hash = "sha256:66c5de72bf4988e1b284ebdd6524c4bead2c507a2d7f172201572bac6f593901", size = 88325, upload-time = "2025-11-03T13:02:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/85/7ba10c9b97c06af6c8f7032ec942ff127558863df52d866019ce9d2425cf/lz4-4.4.5-cp313-cp313t-win_amd64.whl", hash = "sha256:cdd4bdcbaf35056086d910d219106f6a04e1ab0daa40ec0eeef1626c27d0fddb", size = 99643, upload-time = "2025-11-03T13:02:15.978Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4d/a175459fb29f909e13e57c8f475181ad8085d8d7869bd8ad99033e3ee5fa/lz4-4.4.5-cp313-cp313t-win_arm64.whl", hash = "sha256:28ccaeb7c5222454cd5f60fcd152564205bcb801bd80e125949d2dfbadc76bbd", size = 91504, upload-time = "2025-11-03T13:02:17.313Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9c/70bdbdb9f54053a308b200b4678afd13efd0eafb6ddcbb7f00077213c2e5/lz4-4.4.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c216b6d5275fc060c6280936bb3bb0e0be6126afb08abccde27eed23dead135f", size = 207586, upload-time = "2025-11-03T13:02:18.263Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/cb/bfead8f437741ce51e14b3c7d404e3a1f6b409c440bad9b8f3945d4c40a7/lz4-4.4.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c8e71b14938082ebaf78144f3b3917ac715f72d14c076f384a4c062df96f9df6", size = 207161, upload-time = "2025-11-03T13:02:19.286Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/18/b192b2ce465dfbeabc4fc957ece7a1d34aded0d95a588862f1c8a86ac448/lz4-4.4.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9b5e6abca8df9f9bdc5c3085f33ff32cdc86ed04c65e0355506d46a5ac19b6e9", size = 1292415, upload-time = "2025-11-03T13:02:20.829Z" },
+    { url = "https://files.pythonhosted.org/packages/67/79/a4e91872ab60f5e89bfad3e996ea7dc74a30f27253faf95865771225ccba/lz4-4.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b84a42da86e8ad8537aabef062e7f661f4a877d1c74d65606c49d835d36d668", size = 1279920, upload-time = "2025-11-03T13:02:22.013Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/d52c7b11eaa286d49dae619c0eec4aabc0bf3cda7a7467eb77c62c4471f3/lz4-4.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f", size = 1368661, upload-time = "2025-11-03T13:02:23.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/137ddeea14c2cb86864838277b2607d09f8253f152156a07f84e11768a28/lz4-4.4.5-cp314-cp314-win32.whl", hash = "sha256:bd85d118316b53ed73956435bee1997bd06cc66dd2fa74073e3b1322bd520a67", size = 90139, upload-time = "2025-11-03T13:02:24.301Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2c/8332080fd293f8337779a440b3a143f85e374311705d243439a3349b81ad/lz4-4.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:92159782a4502858a21e0079d77cdcaade23e8a5d252ddf46b0652604300d7be", size = 101497, upload-time = "2025-11-03T13:02:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/28/2635a8141c9a4f4bc23f5135a92bbcf48d928d8ca094088c962df1879d64/lz4-4.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:d994b87abaa7a88ceb7a37c90f547b8284ff9da694e6afcfaa8568d739faf3f7", size = 93812, upload-time = "2025-11-03T13:02:26.133Z" },
 ]
 
 [[package]]
@@ -650,6 +724,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pycryptodomex"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/85/e24bf90972a30b0fcd16c73009add1d7d7cd9140c2498a68252028899e41/pycryptodomex-3.23.0.tar.gz", hash = "sha256:71909758f010c82bc99b0abf4ea12012c98962fbf0583c2164f8b84533c2e4da", size = 4922157, upload-time = "2025-05-17T17:23:41.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/00/10edb04777069a42490a38c137099d4b17ba6e36a4e6e28bdc7470e9e853/pycryptodomex-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7b37e08e3871efe2187bc1fd9320cc81d87caf19816c648f24443483005ff886", size = 2498764, upload-time = "2025-05-17T17:22:21.453Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3f/2872a9c2d3a27eac094f9ceaa5a8a483b774ae69018040ea3240d5b11154/pycryptodomex-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:91979028227543010d7b2ba2471cf1d1e398b3f183cb105ac584df0c36dac28d", size = 1643012, upload-time = "2025-05-17T17:22:23.702Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/774c2e2b4f6570fbf6a4972161adbb183aeeaa1863bde31e8706f123bf92/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b8962204c47464d5c1c4038abeadd4514a133b28748bcd9fa5b6d62e3cec6fa", size = 2187643, upload-time = "2025-05-17T17:22:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a3/71065b24cb889d537954cedc3ae5466af00a2cabcff8e29b73be047e9a19/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a33986a0066860f7fcf7c7bd2bc804fa90e434183645595ae7b33d01f3c91ed8", size = 2273762, upload-time = "2025-05-17T17:22:28.313Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0b/ff6f43b7fbef4d302c8b981fe58467b8871902cdc3eb28896b52421422cc/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7947ab8d589e3178da3d7cdeabe14f841b391e17046954f2fbcd941705762b5", size = 2313012, upload-time = "2025-05-17T17:22:30.57Z" },
+    { url = "https://files.pythonhosted.org/packages/02/de/9d4772c0506ab6da10b41159493657105d3f8bb5c53615d19452afc6b315/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c25e30a20e1b426e1f0fa00131c516f16e474204eee1139d1603e132acffc314", size = 2186856, upload-time = "2025-05-17T17:22:32.819Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ad/8b30efcd6341707a234e5eba5493700a17852ca1ac7a75daa7945fcf6427/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:da4fa650cef02db88c2b98acc5434461e027dce0ae8c22dd5a69013eaf510006", size = 2347523, upload-time = "2025-05-17T17:22:35.386Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/02/16868e9f655b7670dbb0ac4f2844145cbc42251f916fc35c414ad2359849/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:58b851b9effd0d072d4ca2e4542bf2a4abcf13c82a29fd2c93ce27ee2a2e9462", size = 2272825, upload-time = "2025-05-17T17:22:37.632Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/18/4ca89ac737230b52ac8ffaca42f9c6f1fd07c81a6cd821e91af79db60632/pycryptodomex-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:a9d446e844f08299236780f2efa9898c818fe7e02f17263866b8550c7d5fb328", size = 1772078, upload-time = "2025-05-17T17:22:40Z" },
+    { url = "https://files.pythonhosted.org/packages/73/34/13e01c322db027682e00986873eca803f11c56ade9ba5bbf3225841ea2d4/pycryptodomex-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:bc65bdd9fc8de7a35a74cab1c898cab391a4add33a8fe740bda00f5976ca4708", size = 1803656, upload-time = "2025-05-17T17:22:42.139Z" },
+    { url = "https://files.pythonhosted.org/packages/54/68/9504c8796b1805d58f4425002bcca20f12880e6fa4dc2fc9a668705c7a08/pycryptodomex-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:c885da45e70139464f082018ac527fdaad26f1657a99ee13eecdce0f0ca24ab4", size = 1707172, upload-time = "2025-05-17T17:22:44.704Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9c/1a8f35daa39784ed8adf93a694e7e5dc15c23c741bbda06e1d45f8979e9e/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:06698f957fe1ab229a99ba2defeeae1c09af185baa909a31a5d1f9d42b1aaed6", size = 2499240, upload-time = "2025-05-17T17:22:46.953Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/62/f5221a191a97157d240cf6643747558759126c76ee92f29a3f4aee3197a5/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2c2537863eccef2d41061e82a881dcabb04944c5c06c5aa7110b577cc487545", size = 1644042, upload-time = "2025-05-17T17:22:49.098Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/fd/5a054543c8988d4ed7b612721d7e78a4b9bf36bc3c5ad45ef45c22d0060e/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43c446e2ba8df8889e0e16f02211c25b4934898384c1ec1ec04d7889c0333587", size = 2186227, upload-time = "2025-05-17T17:22:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a9/8862616a85cf450d2822dbd4fff1fcaba90877907a6ff5bc2672cafe42f8/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f489c4765093fb60e2edafdf223397bc716491b2b69fe74367b70d6999257a5c", size = 2272578, upload-time = "2025-05-17T17:22:53.676Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/bda9c49a7c1842820de674ab36c79f4fbeeee03f8ff0e4f3546c3889076b/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdc69d0d3d989a1029df0eed67cc5e8e5d968f3724f4519bd03e0ec68df7543c", size = 2312166, upload-time = "2025-05-17T17:22:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/03/cc/870b9bf8ca92866ca0186534801cf8d20554ad2a76ca959538041b7a7cf4/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6bbcb1dd0f646484939e142462d9e532482bc74475cecf9c4903d4e1cd21f003", size = 2185467, upload-time = "2025-05-17T17:22:59.237Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e3/ce9348236d8e669fea5dd82a90e86be48b9c341210f44e25443162aba187/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:8a4fcd42ccb04c31268d1efeecfccfd1249612b4de6374205376b8f280321744", size = 2346104, upload-time = "2025-05-17T17:23:02.112Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e869bcee87beb89040263c416a8a50204f7f7a83ac11897646c9e71e0daf/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55ccbe27f049743a4caf4f4221b166560d3438d0b1e5ab929e07ae1702a4d6fd", size = 2271038, upload-time = "2025-05-17T17:23:04.872Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/67/09ee8500dd22614af5fbaa51a4aee6e342b5fa8aecf0a6cb9cbf52fa6d45/pycryptodomex-3.23.0-cp37-abi3-win32.whl", hash = "sha256:189afbc87f0b9f158386bf051f720e20fa6145975f1e76369303d0f31d1a8d7c", size = 1771969, upload-time = "2025-05-17T17:23:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/69/96/11f36f71a865dd6df03716d33bd07a67e9d20f6b8d39820470b766af323c/pycryptodomex-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:52e5ca58c3a0b0bd5e100a9fbc8015059b05cffc6c66ce9d98b4b45e023443b9", size = 1803124, upload-time = "2025-05-17T17:23:09.267Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/93/45c1cdcbeb182ccd2e144c693eaa097763b08b38cded279f0053ed53c553/pycryptodomex-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:02d87b80778c171445d67e23d1caef279bf4b25c3597050ccd2e13970b57fd51", size = 1707161, upload-time = "2025-05-17T17:23:11.414Z" },
 ]
 
 [[package]]
@@ -1112,6 +1216,18 @@ wheels = [
 ]
 
 [[package]]
+name = "shadowcopy"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wmi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/44/c00420a3b7bcdf830529b933392b566c876a4944a24f31e126eb6fd28647/shadowcopy-0.0.4.tar.gz", hash = "sha256:ed89817dda065f893607a04c0b7d6b3b34c3507a4711f441111a4bcb1b1826c0", size = 4138, upload-time = "2023-07-08T00:01:35.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/32/fdea8e7f7b2b8bae13ee6ab7df1a10d28a24dbeb03a62ff033563f95d77c/shadowcopy-0.0.4-py3-none-any.whl", hash = "sha256:fc51e59a639dc6a5a3a7a9b4e3ecadc71989e339f2d995d90aaa491acd4ba4eb", size = 4212, upload-time = "2023-07-08T00:01:34.042Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1288,4 +1404,16 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]
+
+[[package]]
+name = "wmi"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/66/6364deb0a03415f96c66803d8c4379f808f2401da3bdb183348487b10510/WMI-1.5.1.tar.gz", hash = "sha256:b6a6be5711b1b6c8d55bda7a8befd75c48c12b770b9d227d31c1737dbf0d40a6", size = 26254, upload-time = "2020-04-28T08:22:58.096Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/b9/a80d1ed4d115dac8e2ac08d16af046a77ab58e3d186e22395bf2add24090/WMI-1.5.1-py2.py3-none-any.whl", hash = "sha256:1d6b085e5c445141c475476000b661f60fff1aaa19f76bf82b7abb92e0ff4942", size = 28912, upload-time = "2020-04-28T08:22:56.055Z" },
 ]


### PR DESCRIPTION
跟进 #1 合并后 Copilot code review 的 9 条反馈。

## 真 bug（4 条）

| 位置 | 问题 | 修复 |
|---|---|---|
| `session.py:94` | bootstrap 回来的半残 cookie 会先被写盘再在校验处报错，污染磁盘 | 先校验 `REQUIRED_KEYS`，不合格坚决不 `write_cookies_json` |
| `session.py:77` | 错误提示里写了不存在的 `--from <path>` | 改为真实的 `<path>` 位置参数；模块 docstring 同步 |
| `login.py:48` | `goofish auth login --raw`（无 source）会静默走 auto，`--raw` 被吞 | 抛 `ValueError` 提示正确用法 |
| `browser_cookie.py:83` | `_extract_in_process` 把 `BrowserCookieError`（未知浏览器）也吞成 None，误导为"没登录态" | `extract_goofish_cookies` 入口先调 `_get_loader` re-raise；报错和"没登录态"分开 |

## 工程质量（2 条）

| 位置 | 问题 | 修复 |
|---|---|---|
| `browser_cookie.py:116` | subprocess 脚本 hardcode 白名单少了 `mmstat.com`，两条路径可能漂移 | 提取 `ALLOWED_HOSTS` 模块常量；subprocess 通过 argv 接收，不再 hardcode |
| `browser_cookie.py:227` | `with ThreadPoolExecutor(...) as pool` 退出时 `shutdown(wait=True)`，`cancel()` 对已执行的 future 无效，让"FIRST_COMPLETED 立刻返回"失效 | 手动管理 pool + `shutdown(wait=False, cancel_futures=True)` |

## 测试 + 依赖（3 条）

- `test_session_bootstrap`: 补 `assert not fake_cookies_path.exists()` 断言，锁住"bootstrap 失败不落盘"回归
- `test_browser_cookie`: 加"未知浏览器 vs 无登录态"报错区分测试 + "in-process/subprocess 共用 ALLOWED_HOSTS"的结构断言
- `tests/test_auth_login.py`（新增）：覆盖 `--raw` 无 source / 无参数 auto / 文件路径三条路径
- `uv.lock` 同步 `browser-cookie3` + 传递依赖（lz4 / pycryptodomex 等）

## 未采纳（1 条）

`login.py _parse_json` 抛 `AuthRequiredError` 而非 `ValueError` — Copilot 自己标了 `low confidence`。保留 `AuthRequiredError` 的 exit_code 77 对 AI agent 更友好（能独立识别"认证相关问题"）；若改成 `ValueError` 会被 `cli.py` wrapper 归到通用 exit_code 1。

## Test plan

- [x] `pytest`：54 个单测全绿（原 48 + 新增 6）
- [x] `ruff check`：零告警
- [x] 真实验证：`auth login` 无参数 → 22 个完整 cookie；`--raw` 无 source → `ValueError`；`--browser foobar` → 明确报"不认识的浏览器"；`GOOFISH_NO_CHROME_BOOTSTRAP=1` 错误提示已无 `--from` 字样