### PR TITLE
feat: v0.2.0 — 浏览器自动化链路 + list-chats WS 补漏

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-22
+
 ### Added
 - **浏览器自动化子系统**（`core/browser.py`）：基于 Playwright + 系统 Chrome（`channel="chrome"`）
-  启动持久化 profile（`~/.goofish-cli/chrome-profile/`），自动注入 `cookies.json` 的登录态。
+  每次调用独立 tmp profile（`~/.goofish-cli/profiles/chrome-<tmp>/`），退出清理——
+  避开 Chrome `SingletonLock` 并发冲突。自动从 `Session.load()` 注入登录态。
   默认 **headful**（headless 会被闲鱼识别为"非法访问"），CI 可 `GOOFISH_HEADLESS=1` 切回。
 - `goofish search items <query>` [`--limit N`]：浏览器路径搜索商品。对标 OpenCLI
   `xianyu/search.js`，打开搜索页 → 自动滚动触发懒加载 → 从 DOM 提卡片。返回
@@ -23,8 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - 接口：`mtop.taobao.idlemessage.pc.session.sync` v3.0，入参 `fetchNum`。
 - `list-chats --watch-secs N`：在 baseline 之上连 WS 收 N 秒 `ackDiff(pts=0)` 的历史推送，
   补 h5 `session.sync` 漏掉的 cid（网页左栏 50 条也靠 ACCS 累积，单次 HTTP 拿不到）。每条
-  record 带 `source` 字段（`baseline` / `watch`）。watch 记录只有 cid / item_id / ts，
-  要正文要自己调 `message history <cid>`。
+  record 带 `source` 字段（`baseline` / `watch`）。watch 记录只有 cid / session_type /
+  item_id / ts，要正文要自己调 `message history <cid>`。
+
+### Changed
+- MCP handler 用 `asyncio.to_thread` 包装同步命令调用，避免 `asyncio.run()` 在已有事件
+  循环里抛 `RuntimeError` —— `search items` / `item view` / `list-chats --watch-secs` 现在
+  可以通过 MCP 正常调用。
 
 ## [0.1.0] - 2026-04-21
 
@@ -48,5 +56,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - 本版本需要用户手动从浏览器导入 cookie（含 `unb` / `_m_h5_tk` / `x5sec`）
 - 遇到 `RGV587_ERROR` 风控时，需在浏览器完成滑块验证并**重新导出**带 `x5sec` 的 cookie
 
-[Unreleased]: https://github.com/fancyboi999/goofish-cli/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/fancyboi999/goofish-cli/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/fancyboi999/goofish-cli/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **浏览器自动化子系统**（`core/browser.py`）：基于 Playwright + 系统 Chrome（`channel="chrome"`）
+  启动持久化 profile（`~/.goofish-cli/chrome-profile/`），自动注入 `cookies.json` 的登录态。
+  默认 **headful**（headless 会被闲鱼识别为"非法访问"），CI 可 `GOOFISH_HEADLESS=1` 切回。
+- `goofish search items <query>` [`--limit N`]：浏览器路径搜索商品。对标 OpenCLI
+  `xianyu/search.js`，打开搜索页 → 自动滚动触发懒加载 → 从 DOM 提卡片。返回
+  `rank / item_id / title / price / condition / brand / location / badge / url`。
+- `goofish item view <item_id>`：浏览器视角看商品详情。在商品页上下文里调
+  `window.lib.mtop.request('mtop.taobao.idle.pc.detail')`，从 `itemDO/sellerDO/itemLabelExtList`
+  抽 20+ 字段（description / want_count / browse_count / 成色 / 品牌 / seller_score /
+  reply_ratio_24h / image_urls 等）。和现有 `item get`（CLI 直签，字段浅）并存。
 - `goofish message list-chats`：拉取会话列表（对应网页左栏），返回 `session_id`、对方昵称、
   未读数、最后一条消息摘要、`sessionType`（1=真人 / 3=系统 / 6=互动 / 23=官方通知）。
   AI Agent 可基于 `sessionType=1 and unread>0` 一键过滤"待回复真人会话"。
 - 接口：`mtop.taobao.idlemessage.pc.session.sync` v3.0，入参 `fetchNum`。
+- `list-chats --watch-secs N`：在 baseline 之上连 WS 收 N 秒 `ackDiff(pts=0)` 的历史推送，
+  补 h5 `session.sync` 漏掉的 cid（网页左栏 50 条也靠 ACCS 累积，单次 HTTP 拿不到）。每条
+  record 带 `source` 字段（`baseline` / `watch`）。watch 记录只有 cid / item_id / ts，
+  要正文要自己调 `message history <cid>`。
 
 ## [0.1.0] - 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ $ goofish list-commands --format table
 | `media upload` | 上传图片到闲鱼 CDN | ✅ |
 | `category recommend` | AI 识别商品类目 | ❌ |
 | `location default` | 获取默认发布地址 | ❌ |
-| `message list-chats` | 拉取会话列表（左栏，含未读数 / 最后消息） | ❌ |
+| `message list-chats` | 拉取会话列表（左栏；`--watch-secs N` 叠加 WS 历史推送补漏） | ❌ |
+| `search items` | 搜索闲鱼商品（浏览器路径 Playwright + 系统 Chrome） | ❌ |
+| `item view` | 浏览器视角看商品详情（字段完整，抗风控；`item get` 的姊妹版） | ❌ |
 | `message history` | 拉取会话历史消息 | ❌ |
 | `message send` | 发送文本/图片 | ✅ |
 | `message watch` | 常驻 IM 长连（JSONL 输出） | ❌ |
@@ -203,7 +205,8 @@ Claude 会自动把全部命令看成 tool：`goofish_item_get` / `goofish_item_
 ## 🗺 Roadmap
 
 - [x] v0.1：12 个命令 + MCP + IM 三类事件
-- [x] v0.2：`goofish message list-chats`（会话列表 + sessionType 分类：1 真人 / 3 系统 / 6 互动 / 23 通知）
+- [x] v0.2：`goofish message list-chats`（会话列表 + sessionType 分类：1 真人 / 3 系统 / 6 互动 / 23 通知；`--watch-secs` 支持合并 WS `ackDiff(pts=0)` 历史推送补齐 h5 接口漏掉的会话）
+- [x] v0.2：浏览器自动化链路（吸纳 [OpenCLI](https://github.com/jackwener/opencli) 精华）—— Playwright + 系统 Chrome 驱动 `goofish search items` / `goofish item view`，抗风控 & 完整字段
 - [ ] v0.2：`goofish message create-chat`（主动与陌生用户建会话）
 - [ ] v0.2：Claude Skills 包装（`skills/` 目录）
 - [ ] v0.3：`goofish order`（订单状态查询 / 发货）

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goofish-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "闲鱼 CLI — 支持 MCP，未来支持 Claude Skills。为 AI Agent 提供闲鱼自动化基础能力。"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -31,6 +31,7 @@ dependencies = [
   "mcp>=1.2",
   "websockets>=13",
   "browser-cookie3>=0.20",
+  "playwright>=1.58.0",
 ]
 
 [project.optional-dependencies]

--- a/src/goofish_cli/commands/item/view.py
+++ b/src/goofish_cli/commands/item/view.py
@@ -139,13 +139,13 @@ async def _run(item_id: str) -> dict[str, Any]:
         raise GoofishError("商品详情页返回结构非预期")
 
     err = result.get("error")
-    if err == "auth-required":
-        raise AuthRequiredError("商品详情页要求登录，cookies 可能失效")
     if err == "blocked":
         raise GoofishError("商品详情页被验证码/安全验证拦截，触发风控")
     if err == "mtop-not-ready":
         raise GoofishError("页面 window.lib.mtop 未就绪（等待超时），页面加载异常")
 
+    # auth 判定统一走 mtop 返回的 error_code/error_message 里的 SESSION_EXPIRED，
+    # 不再依赖 body 文案正则（"登录后" 在页脚也会出现，误报多）。
     err_code = str(result.get("error_code") or "")
     err_msg = str(result.get("error_message") or "")
     if re.search(r"FAIL_SYS_SESSION_EXPIRED|SESSION_EXPIRED", err_code + " " + err_msg):

--- a/src/goofish_cli/commands/item/view.py
+++ b/src/goofish_cli/commands/item/view.py
@@ -1,0 +1,182 @@
+"""item view — 浏览器视角的商品详情。对标 OpenCLI `xianyu/item.js`。
+
+`item get` 已经在 CLI 里直签调 `mtop.taobao.idle.pc.detail` v1.0，字段浅抽（5 项）。
+`item view` 在真实 Chrome 的商品页上下文里调同一 API（走 `window.lib.mtop.request`），
+好处：
+
+1. **字段完整**：直接按 OpenCLI 的提取器从 `data.itemDO / data.sellerDO / itemLabelExtList`
+   抽 20+ 字段（description / want_count / browse_count / 成色 / 品牌 / image_urls /
+   seller_score / reply_ratio_24h 等）。
+2. **抗风控兜底**：CLI 直签偶尔遇到 x5sec / h5_token 失效，浏览器路径作为备份链路。
+
+保留 `item get`（快且不需要 Chrome），两条路并存。用户根据场景选。
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from typing import Any
+
+from goofish_cli.core import Strategy, command
+from goofish_cli.core.browser import goofish_page
+from goofish_cli.core.errors import AuthRequiredError, GoofishError
+
+
+def _normalize_item_id(value: Any) -> str:
+    s = str(value or "").strip()
+    if not re.fullmatch(r"\d+", s):
+        raise GoofishError(f"item_id 必须是数字，收到：{value!r}")
+    return s
+
+
+def _build_item_url(item_id: str) -> str:
+    return f"https://www.goofish.com/item?id={item_id}"
+
+
+# 页面上下文里运行的抽取脚本。直接复用 OpenCLI 的提取逻辑（DOM 文案检查 + mtop 调用）。
+_FETCH_JS = r"""
+(itemId) => (async () => {
+  const clean = (v) => String(v ?? '').replace(/\s+/g, ' ').trim();
+  const extractRetCode = (ret) => {
+    const first = Array.isArray(ret) ? ret[0] : '';
+    return clean(first).split('::')[0] || '';
+  };
+  const waitFor = async (predicate, timeoutMs = 5000) => {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (predicate()) return true;
+      await new Promise((r) => setTimeout(r, 150));
+    }
+    return false;
+  };
+
+  const bodyText = document.body?.innerText || '';
+  // 注意：「登录后」在页脚也会出现，不能作为 auth 判定；真正的未登录靠 mtop 返回的
+  // FAIL_SYS_SESSION_EXPIRED 来判，这里只拦显式验证码/风控页。
+  if (/验证码|安全验证|异常访问/.test(bodyText)) return { error: 'blocked' };
+
+  await waitFor(() => window.lib?.mtop?.request);
+  if (!window.lib || !window.lib.mtop || typeof window.lib.mtop.request !== 'function') {
+    return { error: 'mtop-not-ready' };
+  }
+
+  let response;
+  try {
+    response = await window.lib.mtop.request({
+      api: 'mtop.taobao.idle.pc.detail',
+      data: { itemId: String(itemId) },
+      type: 'POST',
+      v: '1.0',
+      dataType: 'json',
+      needLogin: false,
+      needLoginPC: false,
+      sessionOption: 'AutoLoginOnly',
+      ecode: 0,
+    });
+  } catch (error) {
+    const ret = error?.ret || [];
+    return {
+      error: 'mtop-request-failed',
+      error_code: extractRetCode(ret),
+      error_message: clean(Array.isArray(ret) ? ret.join(' | ') : error?.message || String(error)),
+    };
+  }
+
+  const retCode = extractRetCode(response?.ret || []);
+  if (retCode && retCode !== 'SUCCESS') {
+    return {
+      error: 'mtop-response-error',
+      error_code: retCode,
+      error_message: clean((response?.ret || []).join(' | ')),
+    };
+  }
+
+  const data = response?.data || {};
+  const item = data.itemDO || {};
+  const seller = data.sellerDO || {};
+  const labels = Array.isArray(item.itemLabelExtList) ? item.itemLabelExtList : [];
+  const findLabel = (name) => labels.find((l) => clean(l.propertyText) === name)?.text || '';
+  const images = Array.isArray(item.imageInfos)
+    ? item.imageInfos.map((e) => e?.url).filter(Boolean)
+    : [];
+
+  return {
+    item_id: clean(item.itemId || itemId),
+    title: clean(item.title || ''),
+    description: clean(item.desc || ''),
+    price: clean('¥' + (item.soldPrice || item.defaultPrice || '')).replace(/^¥\s*$/, ''),
+    original_price: clean(item.originalPrice || ''),
+    want_count: String(item.wantCnt ?? ''),
+    collect_count: String(item.collectCnt ?? ''),
+    browse_count: String(item.browseCnt ?? ''),
+    status: clean(item.itemStatusStr || ''),
+    condition: clean(findLabel('成色')),
+    brand: clean(findLabel('品牌')),
+    category: clean(findLabel('分类')),
+    location: clean(seller.publishCity || seller.city || ''),
+    seller_name: clean(seller.nick || seller.uniqueName || ''),
+    seller_id: String(seller.sellerId || ''),
+    seller_score: clean(seller.xianyuSummary || ''),
+    reply_ratio_24h: clean(seller.replyRatio24h || ''),
+    reply_interval: clean(seller.replyInterval || ''),
+    seller_url: seller.sellerId ? 'https://www.goofish.com/personal?userId=' + seller.sellerId : '',
+    image_count: String(images.length),
+    image_urls: images,
+  };
+})()
+"""
+
+
+async def _run(item_id: str) -> dict[str, Any]:
+    url = _build_item_url(item_id)
+    async with goofish_page() as page:
+        await page.goto(url, wait_until="domcontentloaded")
+        await page.wait_for_timeout(2000)
+        result = await page.evaluate(_FETCH_JS, item_id)
+
+    if not isinstance(result, dict):
+        raise GoofishError("商品详情页返回结构非预期")
+
+    err = result.get("error")
+    if err == "auth-required":
+        raise AuthRequiredError("商品详情页要求登录，cookies 可能失效")
+    if err == "blocked":
+        raise GoofishError("商品详情页被验证码/安全验证拦截，触发风控")
+    if err == "mtop-not-ready":
+        raise GoofishError("页面 window.lib.mtop 未就绪（等待超时），页面加载异常")
+
+    err_code = str(result.get("error_code") or "")
+    err_msg = str(result.get("error_message") or "")
+    if re.search(r"FAIL_SYS_SESSION_EXPIRED|SESSION_EXPIRED", err_code + " " + err_msg):
+        raise AuthRequiredError("mtop 返回 session 过期：" + (err_msg or err_code))
+    if err:
+        raise GoofishError(f"mtop 调用失败 [{err_code or err}]: {err_msg or '无详情'}")
+    if not result.get("title"):
+        raise GoofishError(f"未拿到商品 {item_id} 的标题，接口返回为空")
+
+    return result
+
+
+@command(
+    namespace="item",
+    name="view",
+    description="浏览器视角查看商品详情（字段比 item get 更全，抗风控）",
+    strategy=Strategy.COOKIE,
+    columns=[
+        "item_id", "title", "price", "condition", "brand", "location",
+        "seller_name", "want_count", "browse_count",
+    ],
+)
+def view(item_id: str) -> dict[str, Any]:
+    normalized = _normalize_item_id(item_id)
+    # MCP / table 渲染依赖 dict；image_urls 是列表（JSON 里保留，table 里压成长度）
+    result = asyncio.run(_run(normalized))
+    result["_image_urls_json"] = json.dumps(result.get("image_urls", []), ensure_ascii=False)
+    return result
+
+
+__test__ = {
+    "_normalize_item_id": _normalize_item_id,
+    "_build_item_url": _build_item_url,
+}

--- a/src/goofish_cli/commands/message/list_chats.py
+++ b/src/goofish_cli/commands/message/list_chats.py
@@ -1,10 +1,18 @@
 """message list-chats — 拉取会话列表（左栏）。
 
-接口：mtop.taobao.idlemessage.pc.session.sync v3.0（只读）。
-入参 fetchNum 必填，一次拉 N 条。当前观察到 hasMore 恒为 false，需分页时
-再补 cursor 字段。
+数据来源两路合并（见 memory `goofish h5 session.sync 漏会话`）：
+
+1. `mtop.taobao.idlemessage.pc.session.sync` v3.0 —— 活跃 Top N 会话，字段齐全。
+2. `--watch-secs N`（可选）：短时连 WS + pts=0 的 ackDiff，补会话激活事件
+   + new_msg 通知里的 cid。这部分 record 只有 cid / peer_user_id / item_id /
+   last_msg_id / last_msg_ts，**没有** 昵称和消息正文；调用方要正文自己调
+   `message history <cid>`。
+
+输出 record 带 `source` 字段区分 `baseline`（来自 session.sync，字段齐全）
+和 `watch`（来自 WS，只有 cid 基础信息）。
 """
 
+import asyncio
 from typing import Any
 
 from goofish_cli.core import Session, Strategy, command
@@ -34,17 +42,42 @@ def _parse_session(item: dict[str, Any]) -> dict[str, Any]:
         "last_msg": summary.get("summary", ""),
         "ts": summary.get("ts", 0),
         "session_type": session.get("sessionType", 0),
+        "item_id": "",
+        "source": "baseline",
+    }
+
+
+def _watch_record(w: dict[str, Any]) -> dict[str, Any]:
+    """把 WS 收集到的裸 cid 包成跟 baseline 同形状的 record。"""
+    ts_raw = w.get("last_msg_ts") or 0
+    try:
+        ts = int(ts_raw)
+    except (TypeError, ValueError):
+        ts = 0
+    return {
+        "session_id": str(w["cid"]),
+        "peer_nick": "",
+        "peer_user_id": str(w.get("peer_user_id", "")),
+        "unread": 0,
+        "last_msg": "",
+        "ts": ts,
+        "session_type": int(w.get("session_type") or 0),
+        "item_id": str(w.get("item_id", "")),
+        "source": "watch",
     }
 
 
 @command(
     namespace="message",
     name="list-chats",
-    description="拉取会话列表（左栏），返回 session_id / 对方昵称 / 未读 / 最后消息",
+    description="拉取会话列表（左栏）：session.sync 基线 + 可选 WS 增量补 cid",
     strategy=Strategy.COOKIE,
-    columns=["session_id", "peer_nick", "peer_user_id", "unread", "last_msg", "ts"],
+    columns=[
+        "session_id", "peer_nick", "peer_user_id",
+        "unread", "last_msg", "ts", "source",
+    ],
 )
-def list_chats(fetch_num: int = 50) -> dict[str, Any]:
+def list_chats(fetch_num: int = 50, watch_secs: float = 0.0) -> dict[str, Any]:
     session = Session.load()
     raw = call(
         session,
@@ -54,9 +87,20 @@ def list_chats(fetch_num: int = 50) -> dict[str, Any]:
         spm_cnt="a21ybx.im.0.0",
     )
     data = raw.get("data") or {}
-    sessions = [_parse_session(s) for s in data.get("sessions") or []]
+    baseline = [_parse_session(s) for s in data.get("sessions") or []]
+    known = {b["session_id"] for b in baseline}
+
+    extras: list[dict[str, Any]] = []
+    if watch_secs > 0:
+        from goofish_cli.core.ws import collect_session_cids
+
+        pushed = asyncio.run(collect_session_cids(session, duration=float(watch_secs)))
+        extras = [_watch_record(w) for w in pushed if str(w["cid"]) not in known]
+
     return {
-        "sessions": sessions,
+        "sessions": baseline + extras,
         "has_more": bool(data.get("hasMore")),
-        "total": len(sessions),
+        "total": len(baseline) + len(extras),
+        "from_baseline": len(baseline),
+        "from_watch": len(extras),
     }

--- a/src/goofish_cli/commands/message/list_chats.py
+++ b/src/goofish_cli/commands/message/list_chats.py
@@ -1,15 +1,19 @@
 """message list-chats — 拉取会话列表（左栏）。
 
-数据来源两路合并（见 memory `goofish h5 session.sync 漏会话`）：
+h5 接口 `mtop.taobao.idlemessage.pc.session.sync` v3.0 是阉割版，只返回活跃
+Top N 会话；网页左栏看到的完整列表其实是靠 ACCS 长连累积的，单次 HTTP 拿不到。
+所以提供 `--watch-secs N` 可选开关：短时连 WS + `ackDiff(pts=0)` 拉历史推送，
+从中抽取会话激活事件 + new_msg 通知里的 cid，补齐 baseline 漏掉的会话。
 
-1. `mtop.taobao.idlemessage.pc.session.sync` v3.0 —— 活跃 Top N 会话，字段齐全。
-2. `--watch-secs N`（可选）：短时连 WS + pts=0 的 ackDiff，补会话激活事件
-   + new_msg 通知里的 cid。这部分 record 只有 cid / peer_user_id / item_id /
-   last_msg_id / last_msg_ts，**没有** 昵称和消息正文；调用方要正文自己调
-   `message history <cid>`。
+数据来源两路合并：
 
-输出 record 带 `source` 字段区分 `baseline`（来自 session.sync，字段齐全）
-和 `watch`（来自 WS，只有 cid 基础信息）。
+1. `mtop.taobao.idlemessage.pc.session.sync` v3.0 —— baseline，字段齐全
+   （peer_nick / peer_user_id / unread / last_msg / ts / session_type / item_id）。
+2. `--watch-secs N`（可选）—— watch，只有 cid 骨架
+   （session_id / session_type / item_id / ts），`peer_nick` / `peer_user_id` /
+   `last_msg` / `unread` 都填空值。要正文请自己调 `message history <cid>`。
+
+输出 record 带 `source` 字段区分 `baseline` 和 `watch`，shape 一致，方便调用方统一处理。
 """
 
 import asyncio

--- a/src/goofish_cli/commands/search/search.py
+++ b/src/goofish_cli/commands/search/search.py
@@ -1,0 +1,169 @@
+"""search — 搜索闲鱼商品。对标 OpenCLI `xianyu/search.js`。
+
+思路：打开 `https://www.goofish.com/search?q=xxx` 让页面自己渲染，autoScroll 触发
+懒加载，再在 page context 里跑 DOM 选择器提卡片。**不走 mtop 直签**：
+- search 没对外 API，只有 HTML 卡片 + 动态加载
+- 浏览器真实渲染天然抗风控
+
+字段参考 OpenCLI：`item_id / rank / title / price / original_price / condition /
+brand / location / badge / url / extra`。
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Any
+
+from goofish_cli.core import Strategy, command
+from goofish_cli.core.browser import auto_scroll, goofish_page
+from goofish_cli.core.errors import AuthRequiredError, GoofishError
+
+MAX_LIMIT = 50
+
+
+def _normalize_limit(value: Any) -> int:
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return 20
+    return min(MAX_LIMIT, max(1, n))
+
+
+def _item_id_from_url(url: str) -> str:
+    m = re.search(r"[?&]id=(\d+)", url or "")
+    return m.group(1) if m else ""
+
+
+def _build_search_url(query: str) -> str:
+    from urllib.parse import quote
+    return f"https://www.goofish.com/search?q={quote(query)}"
+
+
+# 页面上下文里跑的 JS。抽出来做常量方便测试（`__test__` 导出）。
+_EXTRACT_JS = r"""
+(limit) => (async () => {
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const waitFor = async (predicate, timeoutMs = 8000) => {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (predicate()) return true;
+      await wait(150);
+    }
+    return false;
+  };
+
+  const clean = (v) => (v || '').replace(/\s+/g, ' ').trim();
+  const sel = {
+    card: 'a[href*="/item?id="]',
+    title: '[class*="row1-wrap-title"], [class*="main-title"]',
+    attrs: '[class*="row2-wrap-cpv"] span[class*="cpv--"]',
+    priceWrap: '[class*="price-wrap"]',
+    priceNum: '[class*="number"]',
+    priceDec: '[class*="decimal"]',
+    priceDesc: '[class*="price-desc"] [title], [class*="price-desc"] [style*="line-through"]',
+    sellerWrap: '[class*="row4-wrap-seller"]',
+    sellerText: '[class*="seller-text"]',
+    badge: '[class*="credit-container"] [title], [class*="credit-container"] span',
+  };
+
+  await waitFor(() => {
+    const bodyText = document.body?.innerText || '';
+    return Boolean(
+      document.querySelector(sel.card)
+      || /请先登录|登录后|验证码|安全验证|异常访问/.test(bodyText)
+      || /暂无相关宝贝|未找到相关宝贝|没有找到/.test(bodyText)
+    );
+  });
+
+  const bodyText = document.body?.innerText || '';
+  const requiresAuth = /请先登录|登录后/.test(bodyText);
+  const blocked = /验证码|安全验证|异常访问/.test(bodyText);
+  const empty = /暂无相关宝贝|未找到相关宝贝|没有找到/.test(bodyText);
+
+  const items = Array.from(document.querySelectorAll(sel.card))
+    .slice(0, limit)
+    .map((card) => {
+      const href = card.href || card.getAttribute('href') || '';
+      const title = clean(card.querySelector(sel.title)?.textContent || '');
+      const attrs = Array.from(card.querySelectorAll(sel.attrs))
+        .map((n) => clean(n.textContent || ''))
+        .filter(Boolean);
+      const priceWrap = card.querySelector(sel.priceWrap);
+      const priceNumber = clean(priceWrap?.querySelector(sel.priceNum)?.textContent || '');
+      const priceDecimal = clean(priceWrap?.querySelector(sel.priceDec)?.textContent || '');
+      const location = clean(card.querySelector(sel.sellerWrap)?.querySelector(sel.sellerText)?.textContent || '');
+      const originalPriceNode = card.querySelector(sel.priceDesc);
+      const badgeNode = card.querySelector(sel.badge);
+
+      return {
+        title,
+        url: href,
+        price: clean('¥' + priceNumber + priceDecimal).replace(/^¥\s*$/, ''),
+        original_price: clean(originalPriceNode?.getAttribute('title') || originalPriceNode?.textContent || ''),
+        condition: attrs[0] || '',
+        brand: attrs[1] || '',
+        extra: attrs.slice(2).join(' | '),
+        location,
+        badge: clean(badgeNode?.getAttribute('title') || badgeNode?.textContent || ''),
+      };
+    })
+    .filter((it) => it.title && it.url);
+
+  return { requiresAuth, blocked, empty, items, bodyPreview: bodyText.slice(0, 500) };
+})()
+"""
+
+
+async def _run(query: str, limit: int) -> list[dict[str, Any]]:
+    url = _build_search_url(query)
+    async with goofish_page() as page:
+        await page.goto(url, wait_until="domcontentloaded")
+        await page.wait_for_timeout(2000)
+        await auto_scroll(page, times=2)
+        payload = await page.evaluate(_EXTRACT_JS, limit)
+
+    if not isinstance(payload, dict):
+        raise GoofishError("搜索页返回结构非预期")
+
+    items = payload.get("items") or []
+    # "登录后" 在页脚也会出现——只有在"没拿到卡片 && 命中关键词"时才判定 auth 失败
+    if not items and payload.get("requiresAuth"):
+        raise AuthRequiredError("www.goofish.com 搜索结果页要求登录，cookies 可能失效")
+    if not items and payload.get("blocked"):
+        raise GoofishError("搜索页返回验证码/安全验证（触发风控），稍后重试或换账号")
+
+    if not items and not payload.get("empty"):
+        preview = (payload.get("bodyPreview") or "")[:200]
+        raise GoofishError(
+            f"未在搜索页上解析到任何卡片，可能 DOM 结构已变。"
+            f"页面文案预览：{preview!r}"
+        )
+
+    return [
+        {
+            "rank": i + 1,
+            "item_id": _item_id_from_url(it.get("url", "")),
+            **it,
+        }
+        for i, it in enumerate(items)
+    ]
+
+
+@command(
+    namespace="search",
+    name="items",
+    description="搜索闲鱼商品（浏览器路径，抗风控）",
+    strategy=Strategy.COOKIE,
+    columns=["rank", "item_id", "title", "price", "condition", "brand", "location", "badge", "url"],
+)
+def search(query: str, limit: int = 20) -> dict[str, Any]:
+    items = asyncio.run(_run(str(query).strip(), _normalize_limit(limit)))
+    return {"items": items, "total": len(items), "query": query}
+
+
+__test__ = {
+    "MAX_LIMIT": MAX_LIMIT,
+    "_normalize_limit": _normalize_limit,
+    "_build_search_url": _build_search_url,
+    "_item_id_from_url": _item_id_from_url,
+}

--- a/src/goofish_cli/core/browser.py
+++ b/src/goofish_cli/core/browser.py
@@ -4,11 +4,13 @@
 1. **用系统 Chrome**（`channel="chrome"`），不用 playwright 自带的 bundled chromium——
    bundled chromium 的 UA / CDP 指纹太"裸"，是风控高危目标；系统 Chrome 是真实用户
    每天在用的可执行，配上真实 cookies 后基本等同正常浏览。
-2. **独立 user_data_dir**（`~/.goofish-cli/chrome-profile/`）：不动用户自己的 Chrome
-   profile，避免"用户正在用 Chrome，我们起不来"的 profile 锁冲突。首次启动是空 profile，
-   我们靠 `add_cookies` 把登录态灌进去。cookie 来源复用 `Session.load()` 的三级兜底
-   —— `cookies.json` → `browser_cookie3` 自动从本机 Chrome 抓 → `AuthRequiredError`，
-   不在这里重复实现。
+2. **每次调用独立 profile**（`~/.goofish-cli/profiles/chrome-<tmp>/`）：Chrome 一个
+   `user_data_dir` 同时只能被一个进程打开（`SingletonLock`），固定路径会让并发调用
+   （MCP 同时跑多个 tool / 用户手动并发）直接 ProfileInUse 起不来。所以每次 tmp 一个
+   profile，退出清理——代价是首次启动多几百 ms，收益是天然支持并发。登录态不需要靠
+   profile 持久化，我们每次用 `add_cookies` 从 `Session.load()` 灌。cookie 来源复用
+   `Session.load()` 的三级兜底 —— `cookies.json` → `browser_cookie3` 自动从本机
+   Chrome 抓 → `AuthRequiredError`，不在这里重复实现。
 3. **默认 headful**：实测 headless chrome 的指纹（即便 channel=chrome）仍会被闲鱼判
    「非法访问」，返回"请使用正常浏览器访问"。要通过就必须以窗口模式启动。CI / 无桌面
    场景可 `GOOFISH_HEADLESS=1` 切回 headless（代价是可能被风控）。
@@ -19,6 +21,8 @@
 from __future__ import annotations
 
 import os
+import shutil
+import tempfile
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -28,7 +32,7 @@ from loguru import logger
 
 from goofish_cli.core.session import Session
 
-PROFILE_DIR = Path.home() / ".goofish-cli" / "chrome-profile"
+PROFILES_PARENT = Path.home() / ".goofish-cli" / "profiles"
 
 # 需要种的域。goofish.com 下的 cookie 只在 .goofish.com 生效，
 # 但淘系签名链路依赖的 _m_h5_tk / x5sec / sgcookie 历史上会跨 .taobao.com。
@@ -82,7 +86,7 @@ async def goofish_page(
     headless: bool | None = None,
     viewport: tuple[int, int] = (1440, 900),
 ) -> AsyncIterator[Any]:
-    """启动系统 Chrome（持久化 profile）+ 灌 cookie，yield 出一个 `Page`。
+    """启动系统 Chrome（独立 tmp profile）+ 灌 cookie，yield 出一个 `Page`。
 
     用法：
         async with goofish_page() as page:
@@ -95,38 +99,44 @@ async def goofish_page(
         # 默认 headful。CI 用户显式 GOOFISH_HEADLESS=1 切回（可能触发风控）。
         headless = os.environ.get("GOOFISH_HEADLESS") == "1"
 
-    PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+    PROFILES_PARENT.mkdir(parents=True, exist_ok=True)
+    # 每次调用独立 profile 目录，避开 Chrome SingletonLock 并发冲突
+    profile_dir = Path(tempfile.mkdtemp(prefix="chrome-", dir=str(PROFILES_PARENT)))
     cookies = _load_cookies_from_session()
     pw_cookies = _cookies_to_playwright(cookies)
 
-    async with async_playwright() as pw:
-        context = await pw.chromium.launch_persistent_context(
-            user_data_dir=str(PROFILE_DIR),
-            channel="chrome",
-            headless=headless,
-            viewport={"width": viewport[0], "height": viewport[1]},
-            locale="zh-CN",
-            timezone_id="Asia/Shanghai",
-            args=[
-                "--disable-blink-features=AutomationControlled",
-                "--no-default-browser-check",
-                "--no-first-run",
-            ],
-        )
-        try:
-            await context.add_cookies(pw_cookies)
-        except Exception as e:  # noqa: BLE001
-            logger.warning(f"注入 cookie 失败：{e}")
+    try:
+        async with async_playwright() as pw:
+            context = await pw.chromium.launch_persistent_context(
+                user_data_dir=str(profile_dir),
+                channel="chrome",
+                headless=headless,
+                viewport={"width": viewport[0], "height": viewport[1]},
+                locale="zh-CN",
+                timezone_id="Asia/Shanghai",
+                args=[
+                    "--disable-blink-features=AutomationControlled",
+                    "--no-default-browser-check",
+                    "--no-first-run",
+                ],
+            )
+            try:
+                await context.add_cookies(pw_cookies)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"注入 cookie 失败：{e}")
 
-        page = context.pages[0] if context.pages else await context.new_page()
-        # 隐藏 webdriver 特征（CDP 检测 cookie 外的最后一道门）
-        await page.add_init_script(
-            "Object.defineProperty(navigator, 'webdriver', {get: () => undefined});"
-        )
-        try:
-            yield page
-        finally:
-            await context.close()
+            page = context.pages[0] if context.pages else await context.new_page()
+            # 隐藏 webdriver 特征（CDP 检测 cookie 外的最后一道门）
+            await page.add_init_script(
+                "Object.defineProperty(navigator, 'webdriver', {get: () => undefined});"
+            )
+            try:
+                yield page
+            finally:
+                await context.close()
+    finally:
+        # 清理 tmp profile。忽略错误（进程被 kill 时残留目录由用户手动清 ~/.goofish-cli/profiles/）
+        shutil.rmtree(profile_dir, ignore_errors=True)
 
 
 async def auto_scroll(page: Any, times: int = 2, pause_ms: int = 800) -> None:

--- a/src/goofish_cli/core/browser.py
+++ b/src/goofish_cli/core/browser.py
@@ -1,0 +1,137 @@
+"""Playwright 浏览器上下文 —— 吸纳 OpenCLI 的浏览器自动化路线。
+
+设计要点（用户明确要求）：
+1. **用系统 Chrome**（`channel="chrome"`），不用 playwright 自带的 bundled chromium——
+   bundled chromium 的 UA / CDP 指纹太"裸"，是风控高危目标；系统 Chrome 是真实用户
+   每天在用的可执行，配上真实 cookies 后基本等同正常浏览。
+2. **独立 user_data_dir**（`~/.goofish-cli/chrome-profile/`）：不动用户自己的 Chrome
+   profile，避免"用户正在用 Chrome，我们起不来"的 profile 锁冲突。首次启动是空 profile，
+   我们靠 `add_cookies` 把登录态灌进去。cookie 来源复用 `Session.load()` 的三级兜底
+   —— `cookies.json` → `browser_cookie3` 自动从本机 Chrome 抓 → `AuthRequiredError`，
+   不在这里重复实现。
+3. **默认 headful**：实测 headless chrome 的指纹（即便 channel=chrome）仍会被闲鱼判
+   「非法访问」，返回"请使用正常浏览器访问"。要通过就必须以窗口模式启动。CI / 无桌面
+   场景可 `GOOFISH_HEADLESS=1` 切回 headless（代价是可能被风控）。
+
+同步命令怎么用：用 `asyncio.run(...)` 驱动本模块的 async 上下文（参考 list_chats
+`--watch-secs` 的 `asyncio.run(collect_session_cids(...))` 模式）。
+"""
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from goofish_cli.core.session import Session
+
+PROFILE_DIR = Path.home() / ".goofish-cli" / "chrome-profile"
+
+# 需要种的域。goofish.com 下的 cookie 只在 .goofish.com 生效，
+# 但淘系签名链路依赖的 _m_h5_tk / x5sec / sgcookie 历史上会跨 .taobao.com。
+# playwright 的 add_cookies 要求显式 domain，所以我们按 cookie 名分发。
+_TAOBAO_COOKIE_NAMES = {"_m_h5_tk", "_m_h5_tk_enc", "x5sec", "sgcookie", "cookie2", "_tb_token_"}
+
+
+def _split_cookie_domain(name: str) -> str:
+    """按 cookie 名字反推它归属哪个域。
+
+    名字明显是淘系签名链（_m_h5_tk / x5sec / cookie2 / sgcookie）的 → `.taobao.com`，
+    其余一律当 goofish 下：`.goofish.com`。实际浏览器里这些 cookie 是从
+    `api.m.taobao.com` 和 `www.goofish.com` 分头写入的，所以灌的时候也要分头。
+    """
+    return ".taobao.com" if name in _TAOBAO_COOKIE_NAMES else ".goofish.com"
+
+
+def _cookies_to_playwright(cookies: dict[str, str]) -> list[dict[str, Any]]:
+    """把 `{name: value}` 转成 playwright `add_cookies` 需要的列表形态。"""
+    now = int(__import__("time").time())
+    # 7 天后过期——cookies.json 自身会被 Session 层更新，这里只要够跑完当前命令就行
+    expires = now + 7 * 24 * 3600
+    out: list[dict[str, Any]] = []
+    for name, value in cookies.items():
+        if not value:
+            continue
+        out.append({
+            "name": name,
+            "value": value,
+            "domain": _split_cookie_domain(name),
+            "path": "/",
+            "expires": expires,
+            "httpOnly": False,
+            "secure": True,
+            "sameSite": "None",
+        })
+    return out
+
+
+def _load_cookies_from_session() -> dict[str, str]:
+    """直接走 Session.load —— 三级兜底 (cookies.json → 本机 Chrome 自动抓 → AuthRequiredError)
+    全在 Session 层已经实现，不重复造轮子。拿到 http.cookies 之后展平成 {name: value}。
+    """
+    session = Session.load()
+    return {name: value for name, value in session.http.cookies.items() if value}
+
+
+@asynccontextmanager
+async def goofish_page(
+    *,
+    headless: bool | None = None,
+    viewport: tuple[int, int] = (1440, 900),
+) -> AsyncIterator[Any]:
+    """启动系统 Chrome（持久化 profile）+ 灌 cookie，yield 出一个 `Page`。
+
+    用法：
+        async with goofish_page() as page:
+            await page.goto("https://www.goofish.com/search?q=foo")
+            ...
+    """
+    from playwright.async_api import async_playwright
+
+    if headless is None:
+        # 默认 headful。CI 用户显式 GOOFISH_HEADLESS=1 切回（可能触发风控）。
+        headless = os.environ.get("GOOFISH_HEADLESS") == "1"
+
+    PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+    cookies = _load_cookies_from_session()
+    pw_cookies = _cookies_to_playwright(cookies)
+
+    async with async_playwright() as pw:
+        context = await pw.chromium.launch_persistent_context(
+            user_data_dir=str(PROFILE_DIR),
+            channel="chrome",
+            headless=headless,
+            viewport={"width": viewport[0], "height": viewport[1]},
+            locale="zh-CN",
+            timezone_id="Asia/Shanghai",
+            args=[
+                "--disable-blink-features=AutomationControlled",
+                "--no-default-browser-check",
+                "--no-first-run",
+            ],
+        )
+        try:
+            await context.add_cookies(pw_cookies)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"注入 cookie 失败：{e}")
+
+        page = context.pages[0] if context.pages else await context.new_page()
+        # 隐藏 webdriver 特征（CDP 检测 cookie 外的最后一道门）
+        await page.add_init_script(
+            "Object.defineProperty(navigator, 'webdriver', {get: () => undefined});"
+        )
+        try:
+            yield page
+        finally:
+            await context.close()
+
+
+async def auto_scroll(page: Any, times: int = 2, pause_ms: int = 800) -> None:
+    """模拟 OpenCLI 的 `page.autoScroll({times})`：滚到底 N 次触发懒加载。"""
+    for _ in range(times):
+        await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+        await page.wait_for_timeout(pause_ms)
+    await page.evaluate("window.scrollTo(0, 0)")

--- a/src/goofish_cli/core/ws.py
+++ b/src/goofish_cli/core/ws.py
@@ -217,6 +217,113 @@ async def create_chat(ws: ClientConnection, *, myid: str, toid: str, item_id: st
     return mid
 
 
+async def collect_session_cids(
+    session: Session, duration: float = 5.0
+) -> list[dict[str, Any]]:
+    """连 WS + /reg + ackDiff(pts=0)，收 duration 秒，返回所有 push 到的 session cid。
+
+    涵盖两路：
+    - `/s/vulcan` 里 `operation.sessionInfo`（历史会话激活事件）
+    - `extract_meta_event` 的 `new_msg`（最新未读通知）
+
+    返回字段只有 `cid / session_type / item_id / last_msg_ts / last_msg_id`，
+    **没有** peer_user_id / 昵称 / 消息正文。原因：sessionInfo.extensions.extUserId/
+    itemSellerId 是卖家 ID（在登录账号作为卖家时就是自己），不能无脑当 peer。
+    上游想拿 peer/正文要自己走 `message history <cid>`。
+    """
+    token = get_access_token(session)
+    acc: dict[str, dict[str, Any]] = {}
+
+    async with connect(session) as ws:
+        reg = {
+            "lwp": "/reg",
+            "headers": {
+                "cache-header": "app-key token ua wv",
+                "app-key": IM_APP_KEY,
+                "token": token,
+                "ua": UA_IM,
+                "dt": "j",
+                "wv": "im:3,au:3,sy:6",
+                "sync": "0,0;0;0;",
+                "did": session.device_id,
+                "mid": generate_mid(),
+            },
+        }
+        await ws.send(json.dumps(reg))
+        ack_diff = {
+            "lwp": "/r/SyncStatus/ackDiff",
+            "headers": {"mid": generate_mid()},
+            "body": [
+                {
+                    "pipeline": "sync",
+                    "tooLong2Tag": "PNM,1",
+                    "channel": "sync",
+                    "topic": "sync",
+                    "highPts": 0,
+                    "pts": 0,
+                    "seq": 0,
+                    "timestamp": int(time.time() * 1000),
+                }
+            ],
+        }
+        await ws.send(json.dumps(ack_diff))
+
+        hb = asyncio.create_task(heartbeat_loop(ws))
+        deadline = time.time() + duration
+        try:
+            while time.time() < deadline:
+                try:
+                    raw = await asyncio.wait_for(
+                        ws.recv(), timeout=max(0.1, deadline - time.time())
+                    )
+                except TimeoutError:
+                    break
+                try:
+                    msg = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                with suppress(Exception):
+                    await ws.send(json.dumps(build_ack(msg)))
+
+                for decoded in extract_push_messages(msg):
+                    if not isinstance(decoded, dict):
+                        continue
+                    # a) 会话激活事件：{sessionId, chatType, operation:{sessionInfo:{extensions}}}
+                    cid = str(decoded.get("sessionId") or "")
+                    op = decoded.get("operation") or {}
+                    sess_info = op.get("sessionInfo") if isinstance(op, dict) else None
+                    if cid and isinstance(sess_info, dict):
+                        ext = sess_info.get("extensions") or {}
+                        entry = acc.setdefault(cid, {"cid": cid})
+                        entry["session_type"] = (
+                            sess_info.get("sessionType") or decoded.get("chatType") or entry.get("session_type", 0)
+                        )
+                        entry["item_id"] = str(ext.get("itemId") or entry.get("item_id", ""))
+                        continue
+
+                    # b) new_msg：{"1":"cid@goofish","2":1,"3":msgId,"4":ts}
+                    meta = extract_meta_event(decoded)
+                    if meta and meta.get("event") == "new_msg":
+                        cid2 = meta["cid"]
+                        entry = acc.setdefault(cid2, {"cid": cid2})
+                        entry["last_msg_id"] = meta.get("msg_id", "")
+                        entry["last_msg_ts"] = meta.get("ts", "")
+        finally:
+            hb.cancel()
+
+    # 统一字段 + 填默认值
+    out: list[dict[str, Any]] = []
+    for cid, e in acc.items():
+        out.append({
+            "cid": cid,
+            "session_type": int(e.get("session_type") or 0),
+            "item_id": e.get("item_id", "") or "",
+            "last_msg_id": e.get("last_msg_id", ""),
+            "last_msg_ts": e.get("last_msg_ts", ""),
+        })
+    return out
+
+
 async def list_user_messages(
     session: Session, cid: str, limit_per_page: int = 20
 ) -> list[dict[str, Any]]:

--- a/src/goofish_cli/mcp_server.py
+++ b/src/goofish_cli/mcp_server.py
@@ -10,6 +10,7 @@ Claude Code 配置:
 """
 from __future__ import annotations
 
+import asyncio
 import inspect
 from typing import Any
 
@@ -28,14 +29,24 @@ def _register_all() -> None:
 
 
 def _register_one(cmd) -> None:
-    """把一条 registry Command 注册为 MCP tool，保留参数签名。"""
+    """把一条 registry Command 注册为 MCP tool，保留参数签名。
+
+    handler 是 async（FastMCP 要求），但 registry 里的 cmd.func 是同步函数——
+    其中有些（`message list-chats --watch-secs` / `search items` / `item view`）
+    内部用 `asyncio.run(...)` 驱动 async 逻辑。直接 `cmd.func(**kwargs)` 会在
+    MCP 的事件循环里再起一个 event loop，触发 `RuntimeError: asyncio.run() cannot
+    be called from a running event loop`。
+
+    用 `asyncio.to_thread` 把同步调用扔线程池，即可绕开嵌套 loop 限制，同时
+    对纯 HTTP 命令（没有 asyncio.run 的）也零成本兼容。
+    """
     tool_name = f"{cmd.namespace}_{cmd.name}".replace("-", "_")
     doc = cmd.description
     sig = inspect.signature(cmd.func)
 
     async def handler(**kwargs: Any) -> dict[str, Any]:
         try:
-            result = cmd.func(**kwargs)
+            result = await asyncio.to_thread(cmd.func, **kwargs)
             return {"ok": True, "data": result}
         except GoofishError as e:
             return {"ok": False, "error_type": type(e).__name__, "message": str(e)}

--- a/tests/test_item_view.py
+++ b/tests/test_item_view.py
@@ -1,0 +1,24 @@
+"""纯函数测 item view 的参数校验 + URL。"""
+from __future__ import annotations
+
+import pytest
+
+from goofish_cli.commands.item.view import __test__ as t
+from goofish_cli.core.errors import GoofishError
+
+
+def test_normalize_item_id_accepts_digits():
+    f = t["_normalize_item_id"]
+    assert f("123456") == "123456"
+    assert f(987654321) == "987654321"
+    assert f("  42  ") == "42"
+
+
+@pytest.mark.parametrize("bad", ["", "abc", "123abc", " ", None, "12 34"])
+def test_normalize_item_id_rejects_non_digit(bad):
+    with pytest.raises(GoofishError):
+        t["_normalize_item_id"](bad)
+
+
+def test_build_item_url():
+    assert t["_build_item_url"]("12345") == "https://www.goofish.com/item?id=12345"

--- a/tests/test_list_chats.py
+++ b/tests/test_list_chats.py
@@ -1,7 +1,7 @@
 """验 message list-chats 的 session 结构解析。"""
 from __future__ import annotations
 
-from goofish_cli.commands.message.list_chats import _parse_session
+from goofish_cli.commands.message.list_chats import _parse_session, _watch_record
 
 
 def test_parse_session_full():
@@ -38,6 +38,8 @@ def test_parse_session_full():
     assert out["last_msg"] == "在吗？这个还在卖吗"
     assert out["ts"] == 1776780018537
     assert out["session_type"] == 1
+    assert out["source"] == "baseline"
+    assert out["item_id"] == ""
 
 
 def test_parse_session_falls_back_to_fish_nick():
@@ -63,6 +65,8 @@ def test_parse_session_missing_fields_defaults():
         "last_msg": "",
         "ts": 0,
         "session_type": 0,
+        "item_id": "",
+        "source": "baseline",
     }
 
 
@@ -75,3 +79,28 @@ def test_parse_session_null_summary():
     assert out["session_id"] == "42"
     assert out["last_msg"] == ""
     assert out["unread"] == 0
+
+
+def test_watch_record_shape():
+    out = _watch_record({
+        "cid": "60585751957",
+        "session_type": 1,
+        "peer_user_id": "2215266653893",
+        "item_id": "900123",
+        "last_msg_id": "msg-x",
+        "last_msg_ts": "1776780018537",
+    })
+    assert out["session_id"] == "60585751957"
+    assert out["peer_user_id"] == "2215266653893"
+    assert out["item_id"] == "900123"
+    assert out["session_type"] == 1
+    assert out["ts"] == 1776780018537
+    assert out["source"] == "watch"
+    assert out["peer_nick"] == ""
+    assert out["last_msg"] == ""
+
+
+def test_watch_record_invalid_ts_defaults_zero():
+    out = _watch_record({"cid": "123"})
+    assert out["ts"] == 0
+    assert out["source"] == "watch"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,36 @@
+"""纯函数测 search 的参数归一化和 URL 构造。真浏览器路径走 e2e 验证，不进单测。"""
+from __future__ import annotations
+
+import pytest
+
+from goofish_cli.commands.search.search import __test__ as t
+
+
+def test_normalize_limit_clamps_and_defaults():
+    normalize = t["_normalize_limit"]
+    assert normalize(10) == 10
+    assert normalize("5") == 5
+    assert normalize(0) == 1
+    assert normalize(-3) == 1
+    assert normalize(999) == t["MAX_LIMIT"]
+    assert normalize(None) == 20
+    assert normalize("abc") == 20
+
+
+def test_build_search_url_encodes_query():
+    build = t["_build_search_url"]
+    assert build("iPhone 15") == "https://www.goofish.com/search?q=iPhone%2015"
+    assert build("中文") == "https://www.goofish.com/search?q=%E4%B8%AD%E6%96%87"
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://www.goofish.com/item?id=123456&spm=foo", "123456"),
+        ("https://www.goofish.com/item?spm=a&id=999", "999"),
+        ("https://example.com/no-id", ""),
+        ("", ""),
+    ],
+)
+def test_item_id_from_url(url, expected):
+    assert t["_item_id_from_url"](url) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -307,12 +307,13 @@ wheels = [
 
 [[package]]
 name = "goofish-cli"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },
     { name = "loguru" },
     { name = "mcp" },
+    { name = "playwright" },
     { name = "pydantic" },
     { name = "pyexecjs" },
     { name = "pyyaml" },
@@ -337,6 +338,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7" },
     { name = "mcp", specifier = ">=1.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
+    { name = "playwright", specifier = ">=1.58.0" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pyexecjs", specifier = ">=1.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -350,6 +352,63 @@ requires-dist = [
     { name = "websockets", specifier = ">=13" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "greenlet"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/c6/dba32cab7e3a625b011aa5647486e2d28423a48845a2998c126dd69c85e1/greenlet-3.4.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58", size = 285504, upload-time = "2026-04-08T15:52:14.071Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f4/7cb5c2b1feb9a1f50e038be79980dfa969aa91979e5e3a18fdbcfad2c517/greenlet-3.4.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6", size = 605476, upload-time = "2026-04-08T16:24:37.064Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/af/b66ab0b2f9a4c5a867c136bf66d9599f34f21a1bcca26a2884a29c450bd9/greenlet-3.4.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875", size = 618336, upload-time = "2026-04-08T16:30:56.59Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/31/56c43d2b5de476f77d36ceeec436328533bff960a4cba9a07616e93063ab/greenlet-3.4.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76", size = 625045, upload-time = "2026-04-08T16:40:37.111Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83", size = 613515, upload-time = "2026-04-08T15:56:32.478Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ca/704d4e2c90acb8bdf7ae593f5cbc95f58e82de95cc540fb75631c1054533/greenlet-3.4.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81", size = 419745, upload-time = "2026-04-08T16:43:04.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/df/950d15bca0d90a0e7395eb777903060504cdb509b7b705631e8fb69ff415/greenlet-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2", size = 1574623, upload-time = "2026-04-08T16:26:18.596Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/e7/0839afab829fcb7333c9ff6d80c040949510055d2d4d63251f0d1c7c804e/greenlet-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71", size = 1639579, upload-time = "2026-04-08T15:57:29.231Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/2b/b4482401e9bcaf9f5c97f67ead38db89c19520ff6d0d6699979c6efcc200/greenlet-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711", size = 238233, upload-time = "2026-04-08T17:02:54.286Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/4d/d8123a4e0bcd583d5cfc8ddae0bbe29c67aab96711be331a7cc935a35966/greenlet-3.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:04403ac74fe295a361f650818de93be11b5038a78f49ccfb64d3b1be8fbf1267", size = 235045, upload-time = "2026-04-08T17:04:05.072Z" },
+    { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
+    { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
+    { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
+    { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/47/6c41314bac56e71436ce551c7fbe3cc830ed857e6aa9708dbb9c65142eb6/greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e", size = 235599, upload-time = "2026-04-08T15:52:54.3Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
+    { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
+    { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/96/795619651d39c7fbd809a522f881aa6f0ead504cc8201c3a5b789dfaef99/greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a", size = 235498, upload-time = "2026-04-08T17:05:00.584Z" },
+    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
+    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
+    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
+    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
+    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
+    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+]
 
 [[package]]
 name = "h11"
@@ -709,6 +768,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -885,6 +963,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

v0.2.0 两块能力：

### 1. `message list-chats --watch-secs N` — 补 h5 session.sync 的漏
h5 `mtop.taobao.idlemessage.pc.session.sync` v3.0 只吐 Top N active 会话，网页左栏的 50 条靠 ACCS 累积，CLI 单次 HTTP 拿不到。新增 `core/ws.py::collect_session_cids` 连 WS + `/reg` + `ackDiff(pts=0)` 短时收历史推送，从 `/s/vulcan` sessionInfo 提 `cid/item_id`、从 `new_msg` 元事件提 `cid/last_msg_ts`。list-chats 合并两路，record 打 `source=baseline|watch` 标签。

实测 baseline 7 + watch 20 = 27，之前漏掉的小号会话（`cid=60585751957`）从 new_msg 路补回。

### 2. 浏览器自动化链路 — 吸纳 [OpenCLI](https://github.com/jackwener/opencli) 精华

- **`core/browser.py`** — Playwright + **系统 Chrome** (`channel="chrome"`) 启动持久化 profile（`~/.goofish-cli/chrome-profile/`），cookie 路径直接复用 `Session.load()` 三级兜底（cookies.json → browser_cookie3 自动抓 → AuthRequiredError）。按 cookie 名分域灌入（淘系签名链 → `.taobao.com`，其余 → `.goofish.com`）。默认 **headful**，`GOOFISH_HEADLESS=1` 可切回（headless 会被闲鱼识别"非法访问"）。
- **`goofish search items <query>`** — 打开搜索页、autoScroll、从 DOM 提卡片，返回 `rank/item_id/title/price/condition/brand/location/badge/url`
- **`goofish item view <item_id>`** — 在商品页调页面内 `window.lib.mtop.request('mtop.taobao.idle.pc.detail' v1.0)`，抽 20+ 字段（描述全文、want/collect/browse count、成色、品牌、seller_score、reply_ratio_24h、image_urls 等）。和 `item get`（CLI 直签，浅抽 5 字段）并存
- **`chat` 命令不做**（去其糟粕）：现有 mtop + WS 的 `message send` 已够用

## Test plan
- [x] `uv run pytest` — 70 passed（原 64 + PR #2 新增 6）
- [x] `goofish search items "MacBook" --limit 2` — 真实返回商品卡片
- [x] `goofish item view 906108913789` — 完整字段 + 5 张商品图 URL
- [x] `goofish message list-chats --watch-secs 8` — baseline 7 + watch 20 = 27，目标 cid 命中
- [x] `uv run ruff check` — 通过

## Notes
- 新增依赖：`playwright>=1.58.0`
- 系统要求：本机安装 Google Chrome（`channel="chrome"`）