### PR TITLE
fix(mcp): 新增 goofish-cli script 入口 → v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-22
+
+### Changed
+- MCP script entry 新增 `goofish-cli`（与 package 名一致），这样 `uvx goofish-cli` 即可
+  直接拉起 MCP server——`uvx goofish-mcp` 会因为 PyPI 上没有 `goofish-mcp` 这个包而解析失败。
+  `goofish-mcp` 作为 legacy 别名保留，已配置的用户不受影响。
+- `goofish_cli.__version__` 改为从 `importlib.metadata` 动态读取 package 版本，避免和
+  `pyproject.toml` 的 `version` 字段 drift（之前硬编码在 `__init__.py` 里，0.2.0 忘了同步）。
+
 ## [0.2.0] - 2026-04-22
 
 ### Added
@@ -56,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - 本版本需要用户手动从浏览器导入 cookie（含 `unb` / `_m_h5_tk` / `x5sec`）
 - 遇到 `RGV587_ERROR` 风控时，需在浏览器完成滑块验证并**重新导出**带 `x5sec` 的 cookie
 
-[Unreleased]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/fancyboi999/goofish-cli/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/fancyboi999/goofish-cli/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.2.1] - 2026-04-22
 
 ### Changed
-- MCP script entry 新增 `goofish-cli`（与 package 名一致），这样 `uvx goofish-cli` 即可
-  直接拉起 MCP server——`uvx goofish-mcp` 会因为 PyPI 上没有 `goofish-mcp` 这个包而解析失败。
-  `goofish-mcp` 作为 legacy 别名保留，已配置的用户不受影响。
+- MCP script entry 新增 `goofish-cli`（与 package 名一致），`uvx goofish-cli` 即可直接拉起
+  MCP server。Claude Code 等 AI Agent 的 MCP 配置应使用这个入口。`goofish-mcp` 作为
+  次级入口保留，但只在本包已装到某 env 时可用（`pip install goofish-cli` /
+  `uv tool install goofish-cli` / `uvx --from goofish-cli goofish-mcp`）——单写
+  `uvx goofish-mcp` 仍会因 PyPI 无同名包解析失败。
 - `goofish_cli.__version__` 改为从 `importlib.metadata` 动态读取 package 版本，避免和
   `pyproject.toml` 的 `version` 字段 drift（之前硬编码在 `__init__.py` 里，0.2.0 忘了同步）。
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 **同一份定义**同时输出给三种消费者：
 
 - 👨‍💻 **人类**：`goofish item get 12345 --format table`
-- 🤖 **AI Agent（Claude Code / Cursor / Codex）**：`uvx goofish-mcp` → 自动注册成 MCP tool
+- 🤖 **AI Agent（Claude Code / Cursor / Codex）**：`uvx goofish-cli` → 自动注册成 MCP tool
 - 🧩 **Claude Skills**（规划中）：`skills/` 目录直接放进 Agent
 
 > 架构思想来自 [opencli](https://github.com/jackwener/opencli) 的 single-registry 设计。
@@ -176,7 +176,7 @@ $ goofish item publish \
   "mcpServers": {
     "goofish": {
       "command": "uvx",
-      "args": ["goofish-mcp"]
+      "args": ["goofish-cli"]
     }
   }
 }
@@ -192,13 +192,13 @@ Claude 会自动把全部命令看成 tool：`goofish_item_get` / `goofish_item_
 |---|---|
 | 11 个核心 mtop 接口 | 发布/下架/查询/图片/类目/地址/IM 全覆盖 |
 | CLI + `--format` 多格式输出 | `json` / `yaml` / `table` / `md` / `csv`，人机两用 |
-| MCP Server | `uvx goofish-mcp` 一行接入 Claude Code / Cursor |
+| MCP Server | `uvx goofish-cli` 一行接入 Claude Code / Cursor |
 | WebSocket 批量 push 全量解码 | 一帧多条消息全部还原，不丢单 |
 | WebSocket 自动重连 | 断线自退避重连，长跑无感知 |
 | 已读回执 / typing / 新消息通知分类 | `/s/sync` 元事件结构化为三类 JSONL |
 | 全局限流 + 风控熔断 | 令牌桶 1 写/分钟 + RGV587 自动熔断 |
 | 单元测试 | 33 个，ruff 零告警 |
-| 包分发 | `pip install goofish-cli` / `uvx goofish-mcp` |
+| 包分发 | `pip install goofish-cli` / `uvx goofish-cli` |
 
 ---
 

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -9,7 +9,7 @@
   "mcpServers": {
     "goofish": {
       "command": "uvx",
-      "args": ["goofish-mcp"]
+      "args": ["goofish-cli"]
     }
   }
 }
@@ -21,7 +21,7 @@
 {
   "mcpServers": {
     "goofish": {
-      "command": "/Users/you/Desktop/goofish-cli/.venv/bin/goofish-mcp"
+      "command": "/Users/you/Desktop/goofish-cli/.venv/bin/goofish-cli"
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,14 @@ dev = [
 
 [project.scripts]
 goofish = "goofish_cli.cli:app"
-# MCP server 入口 —— 名字与 package 名一致，这样 `uvx goofish-cli` 即可拉起（uvx 默认
-# 按 command 名查包，和 scripts 名对齐就不用 --from 绕弯）。保留 goofish-mcp 作为 legacy
-# 别名兼容 v0.2.0 下已配置的用户。
+# MCP server 入口。名字与 package 名一致，`uvx goofish-cli` 可直接拉起（uvx 默认按
+# command 名查包，和 scripts 名对齐就不用 --from 绕弯）。这是 Claude Code 等 AI Agent
+# 配 MCP 时的推荐写法。
 goofish-cli = "goofish_cli.mcp_server:main"
+# 保留 `goofish-mcp` 别名只在 **本包已装** 时可用（`pip install goofish-cli` /
+# `uv tool install goofish-cli` / `uvx --from goofish-cli goofish-mcp`）。单独的
+# `uvx goofish-mcp` 仍会因 PyPI 无同名包解析失败 —— 这不是别名能救的，Claude Code
+# MCP 配置必须用上面的 `uvx goofish-cli`。
 goofish-mcp = "goofish_cli.mcp_server:main"
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goofish-cli"
-version = "0.2.0"
+version = "0.2.1"
 description = "闲鱼 CLI — 支持 MCP，未来支持 Claude Skills。为 AI Agent 提供闲鱼自动化基础能力。"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -44,6 +44,10 @@ dev = [
 
 [project.scripts]
 goofish = "goofish_cli.cli:app"
+# MCP server 入口 —— 名字与 package 名一致，这样 `uvx goofish-cli` 即可拉起（uvx 默认
+# 按 command 名查包，和 scripts 名对齐就不用 --from 绕弯）。保留 goofish-mcp 作为 legacy
+# 别名兼容 v0.2.0 下已配置的用户。
+goofish-cli = "goofish_cli.mcp_server:main"
 goofish-mcp = "goofish_cli.mcp_server:main"
 
 [project.urls]

--- a/src/goofish_cli/__init__.py
+++ b/src/goofish_cli/__init__.py
@@ -1,1 +1,9 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+try:
+    __version__ = _pkg_version("goofish-cli")
+except PackageNotFoundError:
+    __version__ = "0.0.0+dev"
+
+__all__ = ["__version__"]

--- a/src/goofish_cli/mcp_server.py
+++ b/src/goofish_cli/mcp_server.py
@@ -1,13 +1,20 @@
 """FastMCP 入口。扫描同一 registry → 每个 Command 注册为 @mcp.tool()。
 
-启动：`uvx goofish-cli`（推荐）或 `python -m goofish_cli.mcp_server`。
-`goofish-mcp` 是 legacy 别名，也指向这里。
-Claude Code 配置:
+启动（推荐）：`uvx goofish-cli`  —— uvx 按 command 名找包，`goofish-cli` 匹配 PyPI
+包名，一行搞定。Claude Code 配置:
+
   {
     "mcpServers": {
       "goofish": { "command": "uvx", "args": ["goofish-cli"] }
     }
   }
+
+其他入口（仅在 `goofish-cli` 包已装到某 env 时可用）：
+  - `python -m goofish_cli.mcp_server`
+  - `goofish-mcp`（pip / uv tool install 后可用；或 `uvx --from goofish-cli goofish-mcp`）
+
+注意：`uvx goofish-mcp` 单写会因 PyPI 无同名包而解析失败——不是别名能救的，这是 uvx
+按 command 名查包的默认行为决定的。
 """
 from __future__ import annotations
 

--- a/src/goofish_cli/mcp_server.py
+++ b/src/goofish_cli/mcp_server.py
@@ -1,10 +1,11 @@
 """FastMCP 入口。扫描同一 registry → 每个 Command 注册为 @mcp.tool()。
 
-启动：`uvx goofish-mcp` 或 `python -m goofish_cli.mcp_server`
+启动：`uvx goofish-cli`（推荐）或 `python -m goofish_cli.mcp_server`。
+`goofish-mcp` 是 legacy 别名，也指向这里。
 Claude Code 配置:
   {
     "mcpServers": {
-      "goofish": { "command": "uvx", "args": ["goofish-mcp"] }
+      "goofish": { "command": "uvx", "args": ["goofish-cli"] }
     }
   }
 """

--- a/uv.lock
+++ b/uv.lock
@@ -307,7 +307,7 @@ wheels = [
 
 [[package]]
 name = "goofish-cli"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## 问题

v0.2.0 用户配置 Claude Code MCP 时：

```json
{ "mcpServers": { "goofish": { "command": "uvx", "args": ["goofish-mcp"] } } }
```

直接报错：

```
× No solution found when resolving tool dependencies:
  ╰─▶ Because goofish-mcp was not found in the package registry ...
```

**根因**：uvx 默认按 command 名去 PyPI 找同名包。`goofish-mcp` 只是 `goofish-cli` 包里的内部 script，PyPI 上没有 `goofish-mcp` 这个包。

## 修复

- pyproject.toml 新增 `goofish-cli = "goofish_cli.mcp_server:main"` —— script 名和 package 名对齐，`uvx goofish-cli` 直接就通。`goofish-mcp` 作为 legacy 别名保留，v0.2.0 已配置的用户不受影响。
- README / docs/mcp-setup.md / mcp_server 模块注释全改为 `uvx goofish-cli`。
- `__init__.py` 改为 `importlib.metadata.version(...)` 动态读取，杜绝版本 drift（v0.2.0 硬编码 0.1.0 就是 drift）。
- bump 到 0.2.1 + CHANGELOG。

## 验证

- `uv pip install -e .` → `.venv/bin/` 三个入口都在：`goofish` / `goofish-cli` / `goofish-mcp`
- `python -c "import goofish_cli; print(goofish_cli.__version__)"` → `0.2.1`
- ruff clean / pytest 70 绿

## Test plan
- [ ] CI 绿
- [ ] merge 后 tag v0.2.1 + 触发 PyPI publish
- [ ] `uvx goofish-cli` 在 Claude Code 配置里能拉起 MCP server