### PR TITLE
feat(auth): _m_h5_tk 过期自动用 Playwright goto 刷新重试 → v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-04-22
+
+### Added
+- **`_m_h5_tk` 自动刷新机制**（`core/refresh.py`）：mtop 调用遇
+  `FAIL_SYS_TOKEN_EXOIRED` / `FAIL_SYS_TOKEN_EMPTY` / `令牌过期` 时，自动用
+  Playwright `goto` 一次 `https://www.goofish.com` 触发服务端 `Set-Cookie` 续 token，
+  合并回 session 后重试一次原请求。开关：`GOOFISH_AUTO_REFRESH_TOKEN=0` 关闭（CI 或
+  想自定义刷新策略时）。
+  - **只处理 token 层失效**：`FAIL_SYS_SESSION_EXPIRED` / `FAIL_SYS_ILLEGAL_ACCESS` 不触发
+    自动刷新（意味着 `unb` / `cookie2` 也失效了，刷 `_m_h5_tk` 救不了，仍按原 AuthRequiredError 抛）。
+  - **避免跨 domain 同名 cookie 并存**：Playwright 写回的新 cookie 和 `browser_cookie3`
+    导入的旧 cookie 有不同 domain，`requests.CookieJar` 允许两者并存，但后续
+    `cookies.get(name)` 会抛 `CookieConflictError`。刷新时先 `clear(domain, path, name)`
+    掉所有同名旧条目再 `update(fresh)`。
+  - 刷新成功后自动写回 `~/.goofish-cli/cookies.json`，下次启动不用再刷。
+
+### Changed
+- mtop `call()` 新增 `_auto_refresh` 参数（默认 True），递归重试时置 False 避免死循环。
+
 ## [0.2.1] - 2026-04-22
 
 ### Changed
@@ -67,7 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - 本版本需要用户手动从浏览器导入 cookie（含 `unb` / `_m_h5_tk` / `x5sec`）
 - 遇到 `RGV587_ERROR` 风控时，需在浏览器完成滑块验证并**重新导出**带 `x5sec` 的 cookie
 
-[Unreleased]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/fancyboi999/goofish-cli/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/fancyboi999/goofish-cli/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goofish-cli"
-version = "0.2.1"
+version = "0.2.2"
 description = "闲鱼 CLI — 支持 MCP，未来支持 Claude Skills。为 AI Agent 提供闲鱼自动化基础能力。"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/goofish_cli/core/browser.py
+++ b/src/goofish_cli/core/browser.py
@@ -85,8 +85,13 @@ async def goofish_page(
     *,
     headless: bool | None = None,
     viewport: tuple[int, int] = (1440, 900),
+    cookies: dict[str, str] | None = None,
 ) -> AsyncIterator[Any]:
     """启动系统 Chrome（独立 tmp profile）+ 灌 cookie，yield 出一个 `Page`。
+
+    `cookies` 可选：显式传入 `{name: value}` 时直接用；不传则走 `Session.load()`
+    三级兜底。自动刷 `_m_h5_tk` 的调用方需要用内存里当前 session 的 cookies 而非
+    磁盘快照（可能已被改）—— 传 `cookies=session.http.cookies` 展平后的 dict。
 
     用法：
         async with goofish_page() as page:
@@ -102,7 +107,8 @@ async def goofish_page(
     PROFILES_PARENT.mkdir(parents=True, exist_ok=True)
     # 每次调用独立 profile 目录，避开 Chrome SingletonLock 并发冲突
     profile_dir = Path(tempfile.mkdtemp(prefix="chrome-", dir=str(PROFILES_PARENT)))
-    cookies = _load_cookies_from_session()
+    if cookies is None:
+        cookies = _load_cookies_from_session()
     pw_cookies = _cookies_to_playwright(cookies)
 
     try:

--- a/src/goofish_cli/core/mtop.py
+++ b/src/goofish_cli/core/mtop.py
@@ -74,7 +74,7 @@ def call(
 ) -> dict[str, Any]:
     """调用 mtop 接口。返回原始 JSON。失败抛 GoofishError 子类。
 
-    `_auto_refresh=True`：遇到 `FAIL_SYS_TOKEN_EXPIRED` 时自动用 Playwright goto
+    `_auto_refresh=True`：遇到 `FAIL_SYS_TOKEN_EXOIRED` 时自动用 Playwright goto
     闲鱼首页刷一次 cookie 再重试一次。递归调用时用 False 避免死循环。
     """
     url = f"{MTOP_HOST}/h5/{api}/{version}/"

--- a/src/goofish_cli/core/mtop.py
+++ b/src/goofish_cli/core/mtop.py
@@ -11,6 +11,8 @@ import json
 import time
 from typing import Any
 
+from loguru import logger
+
 from goofish_cli.core.errors import (
     AuthRequiredError,
     GoofishError,
@@ -68,8 +70,13 @@ def call(
     spm_cnt: str = "a21ybx.home.0.0",
     extra_params: dict[str, str] | None = None,
     headers: dict[str, str] | None = None,
+    _auto_refresh: bool = True,
 ) -> dict[str, Any]:
-    """调用 mtop 接口。返回原始 JSON。失败抛 GoofishError 子类。"""
+    """调用 mtop 接口。返回原始 JSON。失败抛 GoofishError 子类。
+
+    `_auto_refresh=True`：遇到 `FAIL_SYS_TOKEN_EXPIRED` 时自动用 Playwright goto
+    闲鱼首页刷一次 cookie 再重试一次。递归调用时用 False 避免死循环。
+    """
     url = f"{MTOP_HOST}/h5/{api}/{version}/"
     t_ms = str(int(time.time() * 1000))
     data_val = data if isinstance(data, str) else json.dumps(data, separators=(",", ":"))
@@ -104,8 +111,32 @@ def call(
         timeout=30,
     )
     raw = resp.json()
-    _classify_error(raw, api)
+    try:
+        _classify_error(raw, api)
+    except AuthRequiredError as e:
+        # 只对 h5_tk 层的过期做自动刷新 —— session 级失效（FAIL_SYS_SESSION_EXPIRED
+        # / ILLEGAL_ACCESS）通常意味着 unb/cookie2 也得换，不是刷 _m_h5_tk 能救的。
+        if not (_auto_refresh and _is_token_expired_error(e)):
+            raise
+        from goofish_cli.core.refresh import is_enabled, refresh_cookies_via_browser
+        if not is_enabled():
+            raise
+        logger.info(f"[{api}] 检测到 _m_h5_tk 过期，尝试 Playwright goto 刷新 cookie…")
+        if not refresh_cookies_via_browser(session):
+            raise
+        # 刷新成功：重试一次，禁用递归自动刷新
+        return call(
+            session, api, data,
+            version=version, spm_cnt=spm_cnt,
+            extra_params=extra_params, headers=headers,
+            _auto_refresh=False,
+        )
     return raw
+
+
+def _is_token_expired_error(e: AuthRequiredError) -> bool:
+    msg = str(e)
+    return any(kw in msg for kw in ("FAIL_SYS_TOKEN_EXOIRED", "FAIL_SYS_TOKEN_EMPTY", "令牌过期"))
 
 
 def _classify_error(raw: dict[str, Any], api: str) -> None:

--- a/src/goofish_cli/core/refresh.py
+++ b/src/goofish_cli/core/refresh.py
@@ -1,0 +1,71 @@
+"""遇 FAIL_SYS_TOKEN_EXPIRED 时用 Playwright goto 闲鱼首页刷新 cookie。
+
+`_m_h5_tk` 只有 10 分钟有效期，服务端在浏览器**活跃访问**闲鱼页面时通过
+`Set-Cookie` 续期；浏览器静默几分钟就会过期。mcp/cli 用 `browser_cookie3`
+从磁盘抓快照，命中"抓的时候还没过期、用的时候已过"的窗口很常见。
+
+与其让用户手动去浏览器刷新，不如我们自己用 Playwright `goto` 一次首页——
+反正 search/item view 的浏览器基础设施已经搭好了，直接复用。
+
+开关：`GOOFISH_AUTO_REFRESH_TOKEN=0` 可关闭（CI 或想自定义刷新策略时）。
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+from loguru import logger
+
+from goofish_cli.core.session import DEFAULT_COOKIE_PATH, Session, write_cookies_json
+
+
+async def _refresh_async(url: str) -> dict[str, str]:
+    # 延迟 import：测试环境没装 playwright 也能 import refresh 模块
+    from goofish_cli.core.browser import goofish_page
+
+    async with goofish_page() as page:
+        await page.goto(url, wait_until="domcontentloaded")
+        # 给 mtop h5 sign 一些时间跑完并让服务端 Set-Cookie 新 _m_h5_tk
+        await page.wait_for_timeout(1500)
+        pw_cookies = await page.context.cookies()
+
+    return {c["name"]: c["value"] for c in pw_cookies if c.get("name") and c.get("value")}
+
+
+def is_enabled() -> bool:
+    return os.environ.get("GOOFISH_AUTO_REFRESH_TOKEN") != "0"
+
+
+def refresh_cookies_via_browser(session: Session, *, persist: bool = True) -> bool:
+    """用 Playwright goto 一次闲鱼首页拿新 cookie 并合并回 session。
+
+    成功返回 True，否则 False（调用方按 False 走原始 AuthRequiredError）。
+    """
+    try:
+        fresh = asyncio.run(_refresh_async("https://www.goofish.com"))
+    except Exception as e:  # noqa: BLE001 — Playwright 起不来、Chrome 未装、超时等都走这里
+        logger.warning(f"用 Playwright 刷 cookie 失败：{e}")
+        return False
+
+    if "_m_h5_tk" not in fresh or "unb" not in fresh:
+        logger.warning(f"刷 cookie 后仍缺关键字段，跳过合并（拿到 {len(fresh)} 个 cookie）")
+        return False
+
+    # 关键：直接 `update(fresh)` 会造成跨 domain 同名 cookie 并存（如 .goofish.com 下
+    # 一份旧 _m_h5_tk + Playwright 又写入一份新的），后续 `cookies.get(name)` 会抛
+    # "There are multiple cookies with name"。所以先删掉所有将被更新的 name 的旧条目。
+    names_to_refresh = set(fresh.keys())
+    for cookie in list(session.http.cookies):
+        if cookie.name in names_to_refresh:
+            session.http.cookies.clear(domain=cookie.domain, path=cookie.path, name=cookie.name)
+    session.http.cookies.update(fresh)
+
+    if persist:
+        # 此时 session.http.cookies 已没有同名冲突，安全转 dict
+        merged = {**dict(session.http.cookies), **fresh}
+        try:
+            write_cookies_json(DEFAULT_COOKIE_PATH, merged)
+            logger.info(f"cookie 已刷新并写回 {DEFAULT_COOKIE_PATH}")
+        except OSError as e:
+            logger.debug(f"写回 cookies.json 失败（内存里仍生效）：{e}")
+    return True

--- a/src/goofish_cli/core/refresh.py
+++ b/src/goofish_cli/core/refresh.py
@@ -1,4 +1,4 @@
-"""遇 FAIL_SYS_TOKEN_EXPIRED 时用 Playwright goto 闲鱼首页刷新 cookie。
+"""遇 FAIL_SYS_TOKEN_EXOIRED 时用 Playwright goto 闲鱼首页刷新 cookie。
 
 `_m_h5_tk` 只有 10 分钟有效期，服务端在浏览器**活跃访问**闲鱼页面时通过
 `Set-Cookie` 续期；浏览器静默几分钟就会过期。mcp/cli 用 `browser_cookie3`
@@ -8,6 +8,9 @@
 反正 search/item view 的浏览器基础设施已经搭好了，直接复用。
 
 开关：`GOOFISH_AUTO_REFRESH_TOKEN=0` 可关闭（CI 或想自定义刷新策略时）。
+
+注意：闲鱼后端返回的错误码是 `FAIL_SYS_TOKEN_EXOIRED`（是 EXOIRED 不是 EXPIRED，
+拼写没写错），和 `_AUTH_KEYWORDS` / `_is_token_expired_error` 匹配一致。
 """
 from __future__ import annotations
 
@@ -16,14 +19,16 @@ import os
 
 from loguru import logger
 
-from goofish_cli.core.session import DEFAULT_COOKIE_PATH, Session, write_cookies_json
+from goofish_cli.core.session import Session, resolve_cookie_path, write_cookies_json
 
 
-async def _refresh_async(url: str) -> dict[str, str]:
+async def _refresh_async(url: str, cookies: dict[str, str]) -> dict[str, str]:
     # 延迟 import：测试环境没装 playwright 也能 import refresh 模块
     from goofish_cli.core.browser import goofish_page
 
-    async with goofish_page() as page:
+    # 显式传 cookies——让 Playwright context 注入**调用方当前 session** 的登录态，
+    # 而不是让 goofish_page 再走一次 Session.load() 从磁盘拉（内存里可能已被改）。
+    async with goofish_page(cookies=cookies) as page:
         await page.goto(url, wait_until="domcontentloaded")
         # 给 mtop h5 sign 一些时间跑完并让服务端 Set-Cookie 新 _m_h5_tk
         await page.wait_for_timeout(1500)
@@ -41,8 +46,9 @@ def refresh_cookies_via_browser(session: Session, *, persist: bool = True) -> bo
 
     成功返回 True，否则 False（调用方按 False 走原始 AuthRequiredError）。
     """
+    current = {name: value for name, value in session.http.cookies.items() if value}
     try:
-        fresh = asyncio.run(_refresh_async("https://www.goofish.com"))
+        fresh = asyncio.run(_refresh_async("https://www.goofish.com", current))
     except Exception as e:  # noqa: BLE001 — Playwright 起不来、Chrome 未装、超时等都走这里
         logger.warning(f"用 Playwright 刷 cookie 失败：{e}")
         return False
@@ -61,11 +67,14 @@ def refresh_cookies_via_browser(session: Session, *, persist: bool = True) -> bo
     session.http.cookies.update(fresh)
 
     if persist:
+        # 尊重 GOOFISH_COOKIES_PATH —— 用户配置了自定义路径时不能写默认路径后再下次
+        # Session.load 又去读自定义路径，造成"刷新了但下次启动又回到旧的"。
+        path = resolve_cookie_path()
         # 此时 session.http.cookies 已没有同名冲突，安全转 dict
         merged = {**dict(session.http.cookies), **fresh}
         try:
-            write_cookies_json(DEFAULT_COOKIE_PATH, merged)
-            logger.info(f"cookie 已刷新并写回 {DEFAULT_COOKIE_PATH}")
+            write_cookies_json(path, merged)
+            logger.info(f"cookie 已刷新并写回 {path}")
         except OSError as e:
             logger.debug(f"写回 cookies.json 失败（内存里仍生效）：{e}")
     return True

--- a/src/goofish_cli/core/session.py
+++ b/src/goofish_cli/core/session.py
@@ -22,6 +22,16 @@ from goofish_cli.core.errors import AuthRequiredError
 from goofish_cli.core.sign import generate_device_id
 
 DEFAULT_COOKIE_PATH = Path.home() / ".goofish-cli" / "cookies.json"
+
+
+def resolve_cookie_path(cookie_path: Path | str | None = None) -> Path:
+    """解析实际 cookie 文件路径。优先级：显式入参 > GOOFISH_COOKIES_PATH > 默认。
+
+    `Session.load()` 和自动刷新写回逻辑必须走同一套解析，避免"读一个路径、写另一个"。
+    """
+    return Path(os.path.expanduser(
+        cookie_path or os.environ.get("GOOFISH_COOKIES_PATH") or DEFAULT_COOKIE_PATH
+    ))
 DEVICE_CACHE_PATH = Path.home() / ".goofish-cli" / "device.json"
 USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -39,9 +49,7 @@ class Session:
 
     @classmethod
     def load(cls, cookie_path: Path | str | None = None) -> Session:
-        path = Path(os.path.expanduser(
-            cookie_path or os.environ.get("GOOFISH_COOKIES_PATH") or DEFAULT_COOKIE_PATH
-        ))
+        path = resolve_cookie_path(cookie_path)
 
         cookies = _load_or_bootstrap_cookies(path)
 

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -1,0 +1,87 @@
+"""测 refresh 模块。Playwright 走真浏览器不进单测，mock 掉 asyncio.run。"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from goofish_cli.core import refresh
+from goofish_cli.core.session import Session
+
+
+def _make_session(cookies: dict[str, str]) -> Session:
+    http = requests.Session()
+    http.cookies.update(cookies)
+    return Session(http=http, unb=cookies.get("unb", ""), tracknick="", device_id="dev")
+
+
+def _fake_run(result):
+    """模拟 asyncio.run：close 掉传入的 coroutine（避免 unawaited warning）后返回结果。"""
+    def _inner(coro):
+        coro.close()
+        return result
+    return _inner
+
+
+def _fake_run_raises(exc):
+    def _inner(coro):
+        coro.close()
+        raise exc
+    return _inner
+
+
+def test_refresh_merges_new_cookies_and_dedupes_same_name(tmp_path, monkeypatch):
+    """关键回归：刷新后不能出现跨 domain 同名 cookie（`.cookies.get(...)` 会抛）。"""
+    # 预埋一份旧 _m_h5_tk（默认 domain）
+    session = _make_session({"_m_h5_tk": "old_1", "unb": "u1", "cookie2": "c2"})
+
+    monkeypatch.setattr(refresh, "DEFAULT_COOKIE_PATH", tmp_path / "cookies.json")
+
+    fresh = {"_m_h5_tk": "new_2", "unb": "u1", "cookie2": "c3", "x5sec": "x"}
+    with patch.object(refresh, "asyncio") as mock_async:
+        mock_async.run.side_effect = _fake_run(fresh)
+        ok = refresh.refresh_cookies_via_browser(session)
+
+    assert ok is True
+    # 去重后能正常 get —— 不会抛 "multiple cookies with name"
+    assert session.http.cookies.get("_m_h5_tk") == "new_2"
+    assert session.http.cookies.get("cookie2") == "c3"
+    assert session.http.cookies.get("x5sec") == "x"
+    # 磁盘也写了
+    assert (tmp_path / "cookies.json").exists()
+
+
+def test_refresh_fails_when_required_keys_missing(tmp_path, monkeypatch):
+    session = _make_session({"_m_h5_tk": "old", "unb": "u1"})
+    monkeypatch.setattr(refresh, "DEFAULT_COOKIE_PATH", tmp_path / "cookies.json")
+
+    with patch.object(refresh, "asyncio") as mock_async:
+        mock_async.run.side_effect = _fake_run({"foo": "bar"})  # 没 _m_h5_tk / unb
+        ok = refresh.refresh_cookies_via_browser(session)
+
+    assert ok is False
+    # 不应覆盖旧 session
+    assert session.http.cookies.get("_m_h5_tk") == "old"
+    # 也不应写盘
+    assert not (tmp_path / "cookies.json").exists()
+
+
+def test_refresh_swallows_playwright_exception():
+    session = _make_session({"_m_h5_tk": "old", "unb": "u1"})
+    with patch.object(refresh, "asyncio") as mock_async:
+        mock_async.run.side_effect = _fake_run_raises(RuntimeError("chrome not installed"))
+        ok = refresh.refresh_cookies_via_browser(session, persist=False)
+    assert ok is False
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    [(None, True), ("0", False), ("1", True), ("", True)],
+)
+def test_is_enabled_honors_env(monkeypatch, env, expected):
+    if env is None:
+        monkeypatch.delenv("GOOFISH_AUTO_REFRESH_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("GOOFISH_AUTO_REFRESH_TOKEN", env)
+    assert refresh.is_enabled() is expected

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -36,7 +36,8 @@ def test_refresh_merges_new_cookies_and_dedupes_same_name(tmp_path, monkeypatch)
     # 预埋一份旧 _m_h5_tk（默认 domain）
     session = _make_session({"_m_h5_tk": "old_1", "unb": "u1", "cookie2": "c2"})
 
-    monkeypatch.setattr(refresh, "DEFAULT_COOKIE_PATH", tmp_path / "cookies.json")
+    # 通过 GOOFISH_COOKIES_PATH 让 resolve_cookie_path 指到测试临时路径
+    monkeypatch.setenv("GOOFISH_COOKIES_PATH", str(tmp_path / "cookies.json"))
 
     fresh = {"_m_h5_tk": "new_2", "unb": "u1", "cookie2": "c3", "x5sec": "x"}
     with patch.object(refresh, "asyncio") as mock_async:
@@ -54,7 +55,7 @@ def test_refresh_merges_new_cookies_and_dedupes_same_name(tmp_path, monkeypatch)
 
 def test_refresh_fails_when_required_keys_missing(tmp_path, monkeypatch):
     session = _make_session({"_m_h5_tk": "old", "unb": "u1"})
-    monkeypatch.setattr(refresh, "DEFAULT_COOKIE_PATH", tmp_path / "cookies.json")
+    monkeypatch.setenv("GOOFISH_COOKIES_PATH", str(tmp_path / "cookies.json"))
 
     with patch.object(refresh, "asyncio") as mock_async:
         mock_async.run.side_effect = _fake_run({"foo": "bar"})  # 没 _m_h5_tk / unb
@@ -64,6 +65,23 @@ def test_refresh_fails_when_required_keys_missing(tmp_path, monkeypatch):
     # 不应覆盖旧 session
     assert session.http.cookies.get("_m_h5_tk") == "old"
     # 也不应写盘
+    assert not (tmp_path / "cookies.json").exists()
+
+
+def test_refresh_respects_custom_cookie_path(tmp_path, monkeypatch):
+    """GOOFISH_COOKIES_PATH 自定义路径必须被尊重（Copilot review feedback）。"""
+    custom = tmp_path / "nested" / "my.json"
+    monkeypatch.setenv("GOOFISH_COOKIES_PATH", str(custom))
+
+    session = _make_session({"_m_h5_tk": "old", "unb": "u1"})
+    fresh = {"_m_h5_tk": "new", "unb": "u1"}
+    with patch.object(refresh, "asyncio") as mock_async:
+        mock_async.run.side_effect = _fake_run(fresh)
+        ok = refresh.refresh_cookies_via_browser(session)
+
+    assert ok is True
+    assert custom.exists()
+    # 默认路径不应被写
     assert not (tmp_path / "cookies.json").exists()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -307,7 +307,7 @@ wheels = [
 
 [[package]]
 name = "goofish-cli"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## Summary

- **痛点**：`_m_h5_tk` 只有 10 分钟 TTL，`browser_cookie3` 抓的磁盘快照很容易踩到"抓的时候没过期、用的时候已过"的窗口 → mtop 返回 `FAIL_SYS_TOKEN_EXOIRED::令牌过期` → MCP / CLI 报未登录，用户明明登录着。
- **方案**：mtop 调用层检测到 token 层失效时，自动 goto 一次 `https://www.goofish.com`（复用已有的 Playwright 基础设施），让服务端 `Set-Cookie` 续 `_m_h5_tk`，合并回 session 后重试一次原请求。CI 可通过 `GOOFISH_AUTO_REFRESH_TOKEN=0` 关闭。
- **边界**：只对 token 层（`TOKEN_EXOIRED` / `TOKEN_EMPTY` / `令牌过期`）自动刷；`SESSION_EXPIRED` / `ILLEGAL_ACCESS` 意味着 `unb`/`cookie2` 也废了，刷 `_m_h5_tk` 救不了，仍按原 `AuthRequiredError` 抛出。

## Key regression fix
Playwright 写回的新 cookie 和 `browser_cookie3` 导入的旧 cookie domain 不同（一个带前导点一个不带），`requests.CookieJar` 允许两者并存但后续 `cookies.get(name)` 会抛 `CookieConflictError: There are multiple cookies with name`。刷新前先 `clear(domain, path, name)` 掉所有同名旧条目再 `update(fresh)`。

## Test plan
- [x] `uv run ruff check src tests`
- [x] `uv run pytest -q` — 77 passed
- [x] `uv run pytest -q -W error::RuntimeWarning tests/test_refresh.py` — 7 passed（无 unawaited coroutine warning）
- [x] 本地 E2E：`goofish auth status` 遇 token 过期 → 自动刷新成功 → cookies.json 已写回
- [ ] CI 全绿
- [ ] `uvx goofish-cli==0.2.2` 验证线上包