### PR TITLE
feat(auth): 自动点 passport '快速进入' 免密登录 → v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-04-22
+
+### Added
+- **自动点击 passport 弹窗"快速进入"免密登录**（`core/refresh.py::_try_quick_enter`）：
+  v0.2.2 的 Playwright goto 首页在系统 Chrome 里抓出的 cookie 指纹不匹配时会弹
+  `#alibaba-login-box` 登录框，服务端拒发完整 session cookie 导致后续 mtop 报
+  `FAIL_SYS_SESSION_EXPIRED`。v0.2.3 起自动识别弹窗并点"快速进入"走浏览器免密
+  记忆登录，无需用户交互完成 session 恢复。刷新后追加访问 `/bought` 触发强鉴权页
+  下发完整 `cookie2 / sgcookie / _tb_token_`。
+- `goofish_page()` 已经支持的 `cookies=` 注入点被 refresh 复用，调用方 session
+  和浏览器上下文的登录态保持一致（承接 v0.2.2 Copilot review 的改造）。
+
+### Changed
+- mtop auto-refresh 错误码匹配从"仅 token 层"扩展到**也处理 session 层失效**
+  （`FAIL_SYS_SESSION_EXPIRED`）。`_is_token_expired_error` 重命名为
+  `_is_recoverable_auth_error`，语义更清晰。`FAIL_SYS_ILLEGAL_ACCESS` 仍不在
+  可恢复列表（风控层问题，刷 cookie 救不了）。
+
 ## [0.2.2] - 2026-04-22
 
 ### Added
@@ -86,7 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - 本版本需要用户手动从浏览器导入 cookie（含 `unb` / `_m_h5_tk` / `x5sec`）
 - 遇到 `RGV587_ERROR` 风控时，需在浏览器完成滑块验证并**重新导出**带 `x5sec` 的 cookie
 
-[Unreleased]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/fancyboi999/goofish-cli/compare/v0.1.0...v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goofish-cli"
-version = "0.2.2"
+version = "0.2.3"
 description = "闲鱼 CLI — 支持 MCP，未来支持 Claude Skills。为 AI Agent 提供闲鱼自动化基础能力。"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/goofish_cli/core/mtop.py
+++ b/src/goofish_cli/core/mtop.py
@@ -74,8 +74,10 @@ def call(
 ) -> dict[str, Any]:
     """调用 mtop 接口。返回原始 JSON。失败抛 GoofishError 子类。
 
-    `_auto_refresh=True`：遇到 `FAIL_SYS_TOKEN_EXOIRED` 时自动用 Playwright goto
-    闲鱼首页刷一次 cookie 再重试一次。递归调用时用 False 避免死循环。
+    `_auto_refresh=True`：遇到 token 层（`FAIL_SYS_TOKEN_EXOIRED`）或 session 层
+    （`FAIL_SYS_SESSION_EXPIRED`）失效时，自动用 Playwright 访问闲鱼首页 + 点
+    passport 弹窗的"快速进入"免密登录刷新 cookie 后重试一次。递归调用时置 False
+    避免死循环。
     """
     url = f"{MTOP_HOST}/h5/{api}/{version}/"
     t_ms = str(int(time.time() * 1000))
@@ -114,14 +116,16 @@ def call(
     try:
         _classify_error(raw, api)
     except AuthRequiredError as e:
-        # 只对 h5_tk 层的过期做自动刷新 —— session 级失效（FAIL_SYS_SESSION_EXPIRED
-        # / ILLEGAL_ACCESS）通常意味着 unb/cookie2 也得换，不是刷 _m_h5_tk 能救的。
-        if not (_auto_refresh and _is_token_expired_error(e)):
+        # token 层（_m_h5_tk 过期）和 session 层（cookie2/sgcookie 失效）都可以通过
+        # Playwright goto 闲鱼首页 → 点 passport 弹窗的"快速进入"免密记忆登录恢复。
+        # v0.2.3 起统一由 refresh_cookies_via_browser 处理；`ILLEGAL_ACCESS` 是风控
+        # 层面问题，刷 cookie 也救不了，不在可恢复列表内。
+        if not (_auto_refresh and _is_recoverable_auth_error(e)):
             raise
         from goofish_cli.core.refresh import is_enabled, refresh_cookies_via_browser
         if not is_enabled():
             raise
-        logger.info(f"[{api}] 检测到 _m_h5_tk 过期，尝试 Playwright goto 刷新 cookie…")
+        logger.info(f"[{api}] 检测到登录态失效，尝试 Playwright 免密登录刷新 cookie…")
         if not refresh_cookies_via_browser(session):
             raise
         # 刷新成功：重试一次，禁用递归自动刷新
@@ -134,9 +138,20 @@ def call(
     return raw
 
 
-def _is_token_expired_error(e: AuthRequiredError) -> bool:
+def _is_recoverable_auth_error(e: AuthRequiredError) -> bool:
+    """可通过 Playwright 自动刷新恢复的登录态失效错误码。
+
+    - TOKEN_EXOIRED / TOKEN_EMPTY / 令牌过期 → h5_tk 层，goto 首页即续
+    - SESSION_EXPIRED → session 层，点'快速进入'免密记忆登录恢复
+    - ILLEGAL_ACCESS → 风控层，不在此列（救不了）
+    """
     msg = str(e)
-    return any(kw in msg for kw in ("FAIL_SYS_TOKEN_EXOIRED", "FAIL_SYS_TOKEN_EMPTY", "令牌过期"))
+    return any(kw in msg for kw in (
+        "FAIL_SYS_TOKEN_EXOIRED",
+        "FAIL_SYS_TOKEN_EMPTY",
+        "FAIL_SYS_SESSION_EXPIRED",
+        "令牌过期",
+    ))
 
 
 def _classify_error(raw: dict[str, Any], api: str) -> None:

--- a/src/goofish_cli/core/refresh.py
+++ b/src/goofish_cli/core/refresh.py
@@ -1,37 +1,89 @@
-"""遇 FAIL_SYS_TOKEN_EXOIRED 时用 Playwright goto 闲鱼首页刷新 cookie。
+"""遇 token/session 层失效时用 Playwright 自动刷新 cookie。
 
 `_m_h5_tk` 只有 10 分钟有效期，服务端在浏览器**活跃访问**闲鱼页面时通过
 `Set-Cookie` 续期；浏览器静默几分钟就会过期。mcp/cli 用 `browser_cookie3`
 从磁盘抓快照，命中"抓的时候还没过期、用的时候已过"的窗口很常见。
 
-与其让用户手动去浏览器刷新，不如我们自己用 Playwright `goto` 一次首页——
-反正 search/item view 的浏览器基础设施已经搭好了，直接复用。
+进一步：系统 Chrome 里被 `browser_cookie3` 抓走的 cookie 注入到 Playwright
+tmp profile 后，服务端因为指纹不对会把这份 cookie 视为"半失效 session"，
+首页访问会弹 passport 登录框 —— 弹窗里有 `快速进入`（免密记忆登录）按钮，
+我们自动点一下就能让服务端重新下发完整 session cookie，整个过程用户无感。
+
+流程（v0.2.3）：
+1. goto 首页 → 可能弹 `#alibaba-login-box` 登录 iframe
+2. iframe 里定位 `快速进入` 按钮并点击（免密记忆登录）
+3. 等 modal 消失 → goto `/bought` 触发强鉴权页下发完整 session
+4. 抓 Playwright context.cookies() 作为新快照
 
 开关：`GOOFISH_AUTO_REFRESH_TOKEN=0` 可关闭（CI 或想自定义刷新策略时）。
 
 注意：闲鱼后端返回的错误码是 `FAIL_SYS_TOKEN_EXOIRED`（是 EXOIRED 不是 EXPIRED，
-拼写没写错），和 `_AUTH_KEYWORDS` / `_is_token_expired_error` 匹配一致。
+拼写没写错），和 `_AUTH_KEYWORDS` / `_is_recoverable_auth_error` 匹配一致。
 """
 from __future__ import annotations
 
 import asyncio
 import os
+from typing import Any
 
 from loguru import logger
 
 from goofish_cli.core.session import Session, resolve_cookie_path, write_cookies_json
 
+HOME_URL = "https://www.goofish.com"
+# 强鉴权页，goto 后服务端必须下发完整 session cookie（cookie2/sgcookie/_tb_token_）
+AUTH_PROBE_URL = "https://www.goofish.com/bought"
 
-async def _refresh_async(url: str, cookies: dict[str, str]) -> dict[str, str]:
+
+async def _try_quick_enter(page: Any) -> bool:
+    """闲鱼首页若弹 passport 登录框，点'快速进入'走免密记忆登录。
+
+    无弹窗 → 当作已登录返回 True。
+    有弹窗但按钮不存在或点击失败 → 返回 False（浏览器里可能连免密记忆都清空了，
+    这种情况需要扫码，不在本函数职责内，由调用方决定降级路径）。
+    """
+    iframe_el = await page.query_selector("#alibaba-login-box")
+    if not iframe_el:
+        return True
+    frame = await iframe_el.content_frame()
+    if not frame:
+        logger.debug("[refresh] alibaba-login-box iframe content_frame 未就绪")
+        return False
+    try:
+        await frame.wait_for_load_state("domcontentloaded")
+        # 给 iframe 里的 Vue/React 组件一点时间 mount
+        await page.wait_for_timeout(800)
+        await frame.get_by_text("快速进入", exact=True).first.click(timeout=5000)
+        logger.info("[refresh] 点击 passport '快速进入' 免密登录")
+        await page.wait_for_selector("#alibaba-login-box", state="hidden", timeout=10000)
+        return True
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"[refresh] '快速进入'不可用（浏览器免密记忆可能已失效）：{e}")
+        return False
+
+
+async def _refresh_async(cookies: dict[str, str]) -> dict[str, str]:
     # 延迟 import：测试环境没装 playwright 也能 import refresh 模块
     from goofish_cli.core.browser import goofish_page
 
     # 显式传 cookies——让 Playwright context 注入**调用方当前 session** 的登录态，
     # 而不是让 goofish_page 再走一次 Session.load() 从磁盘拉（内存里可能已被改）。
     async with goofish_page(cookies=cookies) as page:
-        await page.goto(url, wait_until="domcontentloaded")
-        # 给 mtop h5 sign 一些时间跑完并让服务端 Set-Cookie 新 _m_h5_tk
+        await page.goto(HOME_URL, wait_until="domcontentloaded")
+        # 给弹窗 + mtop h5 sign 一些时间渲染
         await page.wait_for_timeout(1500)
+
+        await _try_quick_enter(page)
+
+        # 访问强鉴权页，触发服务端下发完整 session cookies（cookie2 / sgcookie /
+        # _tb_token_ 会被 Set-Cookie 刷新）。即便 /bought 被拦下（未登录降级跳转），
+        # 我们返回 False 的判定仍由调用方对比必需字段完成。
+        try:
+            await page.goto(AUTH_PROBE_URL, wait_until="domcontentloaded", timeout=15000)
+            await page.wait_for_timeout(1500)
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"[refresh] goto {AUTH_PROBE_URL} 异常（忽略）：{e}")
+
         pw_cookies = await page.context.cookies()
 
     return {c["name"]: c["value"] for c in pw_cookies if c.get("name") and c.get("value")}
@@ -42,13 +94,14 @@ def is_enabled() -> bool:
 
 
 def refresh_cookies_via_browser(session: Session, *, persist: bool = True) -> bool:
-    """用 Playwright goto 一次闲鱼首页拿新 cookie 并合并回 session。
+    """用 Playwright 刷一次闲鱼 cookie 合并回 session。
 
-    成功返回 True，否则 False（调用方按 False 走原始 AuthRequiredError）。
+    流程见模块 docstring。成功返回 True，否则 False（调用方按 False 走原始
+    AuthRequiredError 让上层报给用户）。
     """
     current = {name: value for name, value in session.http.cookies.items() if value}
     try:
-        fresh = asyncio.run(_refresh_async("https://www.goofish.com", current))
+        fresh = asyncio.run(_refresh_async(current))
     except Exception as e:  # noqa: BLE001 — Playwright 起不来、Chrome 未装、超时等都走这里
         logger.warning(f"用 Playwright 刷 cookie 失败：{e}")
         return False

--- a/src/goofish_cli/core/refresh.py
+++ b/src/goofish_cli/core/refresh.py
@@ -34,6 +34,11 @@ HOME_URL = "https://www.goofish.com"
 # 强鉴权页，goto 后服务端必须下发完整 session cookie（cookie2/sgcookie/_tb_token_）
 AUTH_PROBE_URL = "https://www.goofish.com/bought"
 
+# 刷新成功的必需字段：`_m_h5_tk`（h5 签名）和 `unb`（用户 id）是任何请求都要的；
+# `cookie2` 是真正的 session token —— 光有 _m_h5_tk/unb 没有 cookie2 仍会被
+# 服务端判定 SESSION_EXPIRED。所以"刷新成功"必须见到 cookie2 被下发。
+_REQUIRED_FRESH_COOKIES = ("_m_h5_tk", "unb", "cookie2")
+
 
 async def _try_quick_enter(page: Any) -> bool:
     """闲鱼首页若弹 passport 登录框，点'快速进入'走免密记忆登录。
@@ -50,7 +55,8 @@ async def _try_quick_enter(page: Any) -> bool:
         logger.debug("[refresh] alibaba-login-box iframe content_frame 未就绪")
         return False
     try:
-        await frame.wait_for_load_state("domcontentloaded")
+        # 显式 timeout：Playwright 默认 30s 太长，会让整个 refresh 流程卡住
+        await frame.wait_for_load_state("domcontentloaded", timeout=5000)
         # 给 iframe 里的 Vue/React 组件一点时间 mount
         await page.wait_for_timeout(800)
         await frame.get_by_text("快速进入", exact=True).first.click(timeout=5000)
@@ -73,11 +79,14 @@ async def _refresh_async(cookies: dict[str, str]) -> dict[str, str]:
         # 给弹窗 + mtop h5 sign 一些时间渲染
         await page.wait_for_timeout(1500)
 
-        await _try_quick_enter(page)
+        # 有弹窗但"快速进入"不可用 → 浏览器免密记忆彻底失效，后续 goto /bought
+        # 也只会被跳登录页。直接返回空 dict 让上层报原始 AuthRequiredError，
+        # 避免返回"只更新了 _m_h5_tk 但 session 仍失效"的假成功 cookies。
+        if not await _try_quick_enter(page):
+            return {}
 
         # 访问强鉴权页，触发服务端下发完整 session cookies（cookie2 / sgcookie /
-        # _tb_token_ 会被 Set-Cookie 刷新）。即便 /bought 被拦下（未登录降级跳转），
-        # 我们返回 False 的判定仍由调用方对比必需字段完成。
+        # _tb_token_ 会被 Set-Cookie 刷新）。
         try:
             await page.goto(AUTH_PROBE_URL, wait_until="domcontentloaded", timeout=15000)
             await page.wait_for_timeout(1500)
@@ -106,8 +115,12 @@ def refresh_cookies_via_browser(session: Session, *, persist: bool = True) -> bo
         logger.warning(f"用 Playwright 刷 cookie 失败：{e}")
         return False
 
-    if "_m_h5_tk" not in fresh or "unb" not in fresh:
-        logger.warning(f"刷 cookie 后仍缺关键字段，跳过合并（拿到 {len(fresh)} 个 cookie）")
+    missing = [k for k in _REQUIRED_FRESH_COOKIES if k not in fresh]
+    if missing:
+        logger.warning(
+            f"刷 cookie 后仍缺关键字段 {missing}（可能'快速进入'未成功或 session 未下发），"
+            f"跳过合并（拿到 {len(fresh)} 个 cookie）"
+        )
         return False
 
     # 关键：直接 `update(fresh)` 会造成跨 domain 同名 cookie 并存（如 .goofish.com 下

--- a/tests/test_mtop.py
+++ b/tests/test_mtop.py
@@ -38,3 +38,22 @@ def test_classify_not_found():
 
     with pytest.raises(NotFoundError):
         _classify_error({"ret": ["FAIL_BIZ_ITEM_NOT_FOUND::商品不存在"]}, "mtop.test")
+
+
+@pytest.mark.parametrize(
+    "msg,expected",
+    [
+        ("[api] 登录态失效：FAIL_SYS_TOKEN_EXOIRED::令牌过期", True),
+        ("[api] 登录态失效：FAIL_SYS_TOKEN_EMPTY::令牌为空", True),
+        ("[api] 登录态失效：FAIL_SYS_SESSION_EXPIRED::Session过期", True),
+        ("[api] 登录态失效：令牌过期", True),
+        # 风控/权限类刷 cookie 救不了，不触发自动刷新
+        ("[api] 登录态失效：FAIL_SYS_ILLEGAL_ACCESS::非法访问", False),
+        ("[api] 未找到：FAIL_BIZ_ITEM_NOT_FOUND", False),
+    ],
+)
+def test_is_recoverable_auth_error(msg, expected):
+    from goofish_cli.core.errors import AuthRequiredError
+    from goofish_cli.core.mtop import _is_recoverable_auth_error
+
+    assert _is_recoverable_auth_error(AuthRequiredError(msg)) is expected

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -74,7 +74,7 @@ def test_refresh_respects_custom_cookie_path(tmp_path, monkeypatch):
     monkeypatch.setenv("GOOFISH_COOKIES_PATH", str(custom))
 
     session = _make_session({"_m_h5_tk": "old", "unb": "u1"})
-    fresh = {"_m_h5_tk": "new", "unb": "u1"}
+    fresh = {"_m_h5_tk": "new", "unb": "u1", "cookie2": "c"}
     with patch.object(refresh, "asyncio") as mock_async:
         mock_async.run.side_effect = _fake_run(fresh)
         ok = refresh.refresh_cookies_via_browser(session)
@@ -82,6 +82,23 @@ def test_refresh_respects_custom_cookie_path(tmp_path, monkeypatch):
     assert ok is True
     assert custom.exists()
     # 默认路径不应被写
+    assert not (tmp_path / "cookies.json").exists()
+
+
+def test_refresh_fails_when_cookie2_missing(tmp_path, monkeypatch):
+    """cookie2 是真正的 session token，缺它必须判失败（v0.2.3 Copilot review）。"""
+    session = _make_session({"_m_h5_tk": "old", "unb": "u1", "cookie2": "old_c"})
+    monkeypatch.setenv("GOOFISH_COOKIES_PATH", str(tmp_path / "cookies.json"))
+
+    # fresh 有 _m_h5_tk / unb 但无 cookie2 —— 过去会误判成功，现在必须 False
+    fresh = {"_m_h5_tk": "new", "unb": "u1"}
+    with patch.object(refresh, "asyncio") as mock_async:
+        mock_async.run.side_effect = _fake_run(fresh)
+        ok = refresh.refresh_cookies_via_browser(session)
+
+    assert ok is False
+    # 旧 cookie 不能被覆盖
+    assert session.http.cookies.get("_m_h5_tk") == "old"
     assert not (tmp_path / "cookies.json").exists()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -307,7 +307,7 @@ wheels = [
 
 [[package]]
 name = "goofish-cli"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## Summary

**问题**：v0.2.2 的 auto-refresh 机制在系统 Chrome 里用 `browser_cookie3` 抓出的 cookie 注入 Playwright tmp profile 后，服务端因指纹不匹配判定 session 半失效 → 弹 `#alibaba-login-box` passport 登录框 → 拒发完整 session cookie → 后续 mtop 报 `FAIL_SYS_SESSION_EXPIRED`。之前 auto-refresh 只对 `TOKEN_EXOIRED` 触发，对 session 层失效束手无策，表现为"MCP 报未登录但浏览器明明登着"。

**方案**：自动化闲鱼 passport 登录框里的**"快速进入"**黄色按钮 —— 这是闲鱼/淘宝的**免密记忆登录**功能，浏览器里保留过账号记忆时就可用，无需扫码、无需账密、**不触发滑块**。

## Changes

- `core/refresh.py::_try_quick_enter`：识别登录 iframe → 点击"快速进入" → 等 modal 消失
- `_refresh_async` 流程：goto 首页 → 尝试免密登录 → goto `/bought` 触发完整 session cookie 下发
- `core/mtop.py::_is_recoverable_auth_error`（原 `_is_token_expired_error`）：从"仅 token 层"扩展到**也处理 SESSION_EXPIRED**。`ILLEGAL_ACCESS` 仍不在可恢复列表（风控层）
- `tests/test_mtop.py` 新增 `_is_recoverable_auth_error` 的 parametrize 测试覆盖

## Test plan
- [x] `uv run ruff check src tests` 全绿
- [x] `uv run pytest -q -W error::RuntimeWarning` — 84 passed
- [x] E2E：本地 `auth status` 从 `valid: false (FAIL_SYS_SESSION_EXPIRED)` → 跑 `refresh_cookies_via_browser` → `valid: true`，全程无人工介入
- [x] 日志可观测：`[refresh] 点击 passport '快速进入' 免密登录` / `cookie 已刷新并写回`
- [ ] CI 全绿
- [ ] `uvx goofish-cli==0.2.3` 线上验证