### PR TITLE
feat(auth): 扫码登录兜底 auth login --qr → v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-04-22
+
+### Added
+- **`auth login --qr` 扫码登录兜底**（`core/qr_login.py`）：v0.2.3 的"快速进入"
+  免密登录依赖浏览器免密记忆，换机 / 长期不登 / 清 cookie 后记忆失效就没法用。
+  v0.2.4 补上扫码路径——Playwright 开干净 tmp profile goto 首页触发 passport
+  iframe（`styleType=vertical` 布局里 QR canvas 首屏就在 DOM 里，无需切 tab），
+  用户用手机闲鱼 App 扫码 + 手机确认后，轮询 `context.cookies()` 直到见到完整
+  session cookie（`_m_h5_tk / unb / cookie2`）即判成功，抓快照写回
+  `~/.goofish-cli/cookies.json`。
+  - `--qr-timeout N`（默认 120s）/ `GOOFISH_QR_TIMEOUT=N` 可调；超时抛
+    `AuthRequiredError`，提示延长超时重试。
+  - 传 `goofish_page(cookies={})` 是关键——不传空 dict 会走 `Session.load` 把
+    已有 cookie 灌进去，passport 就优先走"快速进入"跳过 QR，用户看不到扫码界面。
+  - 和 v0.2.3 refresh 自动路径分工：refresh=无感续命（SESSION_EXPIRED 时自动
+    点"快速进入"），qr_login=显式扫码（需用户拿手机）。不混用，不塞进 refresh
+    自动 retry（扫码时间不可控，会违反"无感"语义）。
+
+### Changed
+- `auth login` 新增 `--qr` / `--qr-timeout` flag；`--qr` 与 `<source>` /
+  `--raw` / `--browser` 互斥，组合使用会直接报错（QR 走独立 Playwright 浏览器，
+  同时传其它来源会让用户困惑）。
+
 ## [0.2.3] - 2026-04-22
 
 ### Added
@@ -104,7 +127,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - 本版本需要用户手动从浏览器导入 cookie（含 `unb` / `_m_h5_tk` / `x5sec`）
 - 遇到 `RGV587_ERROR` 风控时，需在浏览器完成滑块验证并**重新导出**带 `x5sec` 的 cookie
 
-[Unreleased]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.4...HEAD
+[0.2.4]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/fancyboi999/goofish-cli/compare/v0.2.0...v0.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goofish-cli"
-version = "0.2.3"
+version = "0.2.4"
 description = "闲鱼 CLI — 支持 MCP，未来支持 Claude Skills。为 AI Agent 提供闲鱼自动化基础能力。"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/goofish_cli/commands/auth/login.py
+++ b/src/goofish_cli/commands/auth/login.py
@@ -40,7 +40,7 @@ def login(
     raw: bool = False,
     browser: str = "auto",
     qr: bool = False,
-    qr_timeout: int = 120,
+    qr_timeout: int | None = None,
 ) -> dict[str, object]:
     target = DEFAULT_COOKIE_PATH
 
@@ -52,12 +52,18 @@ def login(
                 "--qr 不能与 <source> / --raw / --browser 同时使用"
                 "（QR 走独立的 Playwright 浏览器）"
             )
+        # qr_timeout=None 让 core.qr_login 走统一的 env → 默认值 兜底逻辑；
+        # 这里若写 int 默认（例如 120）会把 env 覆盖路径挡掉（CLI 总是显式传值）。
         from goofish_cli.core.qr_login import login_via_qr
         cookies = login_via_qr(timeout=qr_timeout, persist=False)
         if not cookies:
+            # 空 dict 可能来自两种失败：超时未扫码，或 Playwright 起不来（Chrome
+            # 未装、端口占用等）。文案同时覆盖，让用户知道去翻日志。
             raise AuthRequiredError(
-                f"QR 扫码登录未完成（{qr_timeout}s 内未扫码或手机未确认）。"
-                f"可延长超时：goofish auth login --qr --qr-timeout 180"
+                "QR 扫码登录未完成——可能是超时内未扫码 / 手机未确认，"
+                "也可能是 Playwright 浏览器启动失败（Chrome 未装、端口占用等，"
+                "详见前面的 warning 日志）。可重试并延长超时："
+                "goofish auth login --qr --qr-timeout 180"
             )
         source_label = "qr"
     elif source is None:

--- a/src/goofish_cli/commands/auth/login.py
+++ b/src/goofish_cli/commands/auth/login.py
@@ -10,6 +10,7 @@
 - `auth login --browser edge`      指定单个浏览器
 - `auth login <path>`              从 JSON 文件导入
 - `auth login <cookie_str> --raw`  粘贴 "k=v; k=v" 字符串
+- `auth login --qr`                扫码登录（兜底：浏览器免密记忆失效 / 换机 / 首次用）
 
 触发条件：
 1. 所有浏览器都没拿到 → 报错里列出手动兜底方案
@@ -38,10 +39,28 @@ def login(
     *,
     raw: bool = False,
     browser: str = "auto",
+    qr: bool = False,
+    qr_timeout: int = 120,
 ) -> dict[str, object]:
     target = DEFAULT_COOKIE_PATH
 
-    if source is None:
+    if qr:
+        # QR 和其它来源互斥：QR 会起独立 Playwright 浏览器，source / --raw / 指定
+        # --browser 没意义还会让用户困惑（"我传的 cookie 哪去了？"）
+        if source is not None or raw or browser != "auto":
+            raise ValueError(
+                "--qr 不能与 <source> / --raw / --browser 同时使用"
+                "（QR 走独立的 Playwright 浏览器）"
+            )
+        from goofish_cli.core.qr_login import login_via_qr
+        cookies = login_via_qr(timeout=qr_timeout, persist=False)
+        if not cookies:
+            raise AuthRequiredError(
+                f"QR 扫码登录未完成（{qr_timeout}s 内未扫码或手机未确认）。"
+                f"可延长超时：goofish auth login --qr --qr-timeout 180"
+            )
+        source_label = "qr"
+    elif source is None:
         if raw:
             # --raw 要求紧跟 cookie 字符串；如果没传 source，说明用户漏了参数——
             # 不能静默走浏览器 auto-detect，否则 --raw 被吞，用户会困惑。

--- a/src/goofish_cli/core/qr_login.py
+++ b/src/goofish_cli/core/qr_login.py
@@ -1,0 +1,124 @@
+"""扫码登录——浏览器免密记忆失效时的 auth fallback。
+
+与 v0.2.3 `core/refresh.py` 的分工：
+- refresh：遇 mtop SESSION_EXPIRED 时**自动**点"快速进入"免密登录，无需用户交互。
+- qr_login：用户免密记忆彻底清空（换机 / 长期不登 / 清 cookie）时，走**扫码**
+  拿一份全新 session。必须显式触发（`auth login --qr`），因为需要用户拿手机。
+
+不把 QR 塞进 refresh 自动路径的原因：refresh 的合约是"无感续命"，扫码要用户
+参与，时间不可控，违反合约。所以两条路并存，根据"浏览器是否还认识你"自动/手动选。
+
+passport 页面（`passport.goofish.com/mini_login.htm?...&styleType=vertical`）的
+vertical 布局里扫码区和密码区并排，canvas 首屏就在 DOM 里——不用切 tab。
+
+流程：
+1. `goofish_page(cookies={})` 开**干净 tmp profile**（否则 passport 会优先走"快速
+   进入"跳过 QR）
+2. goto 首页触发 `#alibaba-login-box` iframe
+3. 等 `.qrcode-login canvas` 渲染 → QR 就绪
+4. 轮询 `context.cookies()`：看见 `_m_h5_tk / unb / cookie2` 全到位说明扫码 +
+   手机端确认都过了，抓快照返回
+5. 超时（默认 120s，`GOOFISH_QR_TIMEOUT` 可调）→ 空 dict，上层报 AuthRequiredError
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Any
+
+from loguru import logger
+
+from goofish_cli.core.session import resolve_cookie_path, write_cookies_json
+
+HOME_URL = "https://www.goofish.com"
+
+# 扫码 + 手机确认后，passport 会下发完整 session cookie。这三个齐了才算真的登上：
+# _m_h5_tk 是 h5 签名、unb 是用户 id、cookie2 是 session token。
+_REQUIRED_LOGIN_COOKIES = ("_m_h5_tk", "unb", "cookie2")
+
+_DEFAULT_QR_TIMEOUT = 120
+
+
+async def _wait_for_qr(page: Any, timeout_ms: int = 15000) -> bool:
+    """等 passport iframe 里 QR canvas 渲染出来（说明可扫）。"""
+    try:
+        iframe_el = await page.wait_for_selector("#alibaba-login-box", timeout=timeout_ms)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"[qr] 未检测到 passport iframe：{e}（首页或许已登录？）")
+        return False
+    frame = await iframe_el.content_frame()
+    if not frame:
+        logger.warning("[qr] passport iframe content_frame 未就绪")
+        return False
+    try:
+        await frame.wait_for_load_state("domcontentloaded", timeout=5000)
+        await frame.wait_for_selector(".qrcode-login canvas", timeout=timeout_ms)
+        return True
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"[qr] QR canvas 未渲染：{e}")
+        return False
+
+
+def _has_all_login_cookies(cookies_list: list[dict[str, Any]]) -> bool:
+    names = {c.get("name") for c in cookies_list if c.get("value")}
+    return all(k in names for k in _REQUIRED_LOGIN_COOKIES)
+
+
+async def _login_via_qr_async(timeout: int) -> dict[str, str]:
+    # 延迟 import——单测环境没装 playwright 也能 import 本模块
+    from goofish_cli.core.browser import goofish_page
+
+    # cookies={} 是关键：不传空 dict 会走 Session.load 把现有登录态灌进去，
+    # passport 就优先走"快速进入"跳过 QR，用户看不到扫码界面。
+    async with goofish_page(cookies={}) as page:
+        await page.goto(HOME_URL, wait_until="domcontentloaded")
+        await page.wait_for_timeout(1500)
+
+        if not await _wait_for_qr(page):
+            return {}
+
+        logger.info(f"[qr] 请用手机闲鱼 App 扫码登录（{timeout}s 超时）")
+
+        # 轮询 cookies：扫码 → 手机确认 → passport 下发完整 session 一般 < 5s
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            cookies_list = await page.context.cookies()
+            if _has_all_login_cookies(cookies_list):
+                logger.info("[qr] 扫码成功，session cookies 已下发")
+                return {
+                    c["name"]: c["value"]
+                    for c in cookies_list
+                    if c.get("name") and c.get("value")
+                }
+            await asyncio.sleep(1.0)
+
+        logger.warning(f"[qr] {timeout}s 超时未登录成功")
+        return {}
+
+
+def login_via_qr(*, timeout: int | None = None, persist: bool = True) -> dict[str, str]:
+    """阻塞：起 Playwright 让用户扫码，成功返回 cookies 并可选写回磁盘。
+
+    空 dict 表示超时或 Playwright 异常（Chrome 未装等）。
+    """
+    if timeout is None:
+        timeout = int(os.environ.get("GOOFISH_QR_TIMEOUT") or _DEFAULT_QR_TIMEOUT)
+    try:
+        cookies = asyncio.run(_login_via_qr_async(timeout))
+    except Exception as e:  # noqa: BLE001 — Playwright 起不来、Chrome 未装等都走这里
+        logger.warning(f"QR 扫码登录失败：{e}")
+        return {}
+
+    if not cookies:
+        return {}
+
+    if persist:
+        path = resolve_cookie_path()
+        try:
+            write_cookies_json(path, cookies)
+            logger.info(f"cookie 已写回 {path}")
+        except OSError as e:
+            logger.warning(f"写回 cookies.json 失败（内存里仍生效）：{e}")
+
+    return cookies

--- a/src/goofish_cli/core/qr_login.py
+++ b/src/goofish_cli/core/qr_login.py
@@ -97,13 +97,28 @@ async def _login_via_qr_async(timeout: int) -> dict[str, str]:
         return {}
 
 
+def _resolve_timeout(timeout: int | None) -> int:
+    """timeout=None 时读 env；env 未设或非整数时回退默认值（不让 CLI 崩）。"""
+    if timeout is not None:
+        return timeout
+    raw = os.environ.get("GOOFISH_QR_TIMEOUT")
+    if not raw:
+        return _DEFAULT_QR_TIMEOUT
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            f"GOOFISH_QR_TIMEOUT={raw!r} 不是整数，回退默认 {_DEFAULT_QR_TIMEOUT}s"
+        )
+        return _DEFAULT_QR_TIMEOUT
+
+
 def login_via_qr(*, timeout: int | None = None, persist: bool = True) -> dict[str, str]:
     """阻塞：起 Playwright 让用户扫码，成功返回 cookies 并可选写回磁盘。
 
     空 dict 表示超时或 Playwright 异常（Chrome 未装等）。
     """
-    if timeout is None:
-        timeout = int(os.environ.get("GOOFISH_QR_TIMEOUT") or _DEFAULT_QR_TIMEOUT)
+    timeout = _resolve_timeout(timeout)
     try:
         cookies = asyncio.run(_login_via_qr_async(timeout))
     except Exception as e:  # noqa: BLE001 — Playwright 起不来、Chrome 未装等都走这里

--- a/tests/test_qr_login.py
+++ b/tests/test_qr_login.py
@@ -79,6 +79,38 @@ def test_login_via_qr_respects_env_timeout(monkeypatch):
     assert out == {}
 
 
+def test_login_via_qr_env_invalid_falls_back(monkeypatch):
+    """Copilot review：env 非整数不能让命令崩，要 warn + 回退默认。"""
+    monkeypatch.setenv("GOOFISH_QR_TIMEOUT", "not-a-number")
+    captured: list[int] = []
+
+    async def _record(t):
+        captured.append(t)
+        return {}
+
+    monkeypatch.setattr(qr_login, "_login_via_qr_async", _record)
+    # 不应抛 ValueError
+    out = qr_login.login_via_qr(persist=False)
+
+    assert captured == [qr_login._DEFAULT_QR_TIMEOUT]
+    assert out == {}
+
+
+def test_login_via_qr_explicit_timeout_wins_over_env(monkeypatch):
+    """显式传 timeout 时不读 env。"""
+    monkeypatch.setenv("GOOFISH_QR_TIMEOUT", "999")
+    captured: list[int] = []
+
+    async def _record(t):
+        captured.append(t)
+        return {}
+
+    monkeypatch.setattr(qr_login, "_login_via_qr_async", _record)
+    qr_login.login_via_qr(timeout=42, persist=False)
+
+    assert captured == [42]
+
+
 @pytest.mark.parametrize(
     "cookies,expected",
     [

--- a/tests/test_qr_login.py
+++ b/tests/test_qr_login.py
@@ -1,0 +1,97 @@
+"""测 qr_login 模块。Playwright 走真浏览器不进单测，mock 掉 asyncio.run。"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from goofish_cli.core import qr_login
+
+
+def _fake_run(result):
+    """模拟 asyncio.run：close 掉传入的 coroutine（避免 unawaited warning）后返回结果。"""
+    def _inner(coro):
+        coro.close()
+        return result
+    return _inner
+
+
+def _fake_run_raises(exc):
+    def _inner(coro):
+        coro.close()
+        raise exc
+    return _inner
+
+
+def test_login_via_qr_success_writes_disk(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOOFISH_COOKIES_PATH", str(tmp_path / "cookies.json"))
+    fake = {"_m_h5_tk": "t", "unb": "u", "cookie2": "c", "sgcookie": "s"}
+    with patch.object(qr_login, "asyncio") as mock_async:
+        mock_async.run.side_effect = _fake_run(fake)
+        out = qr_login.login_via_qr(timeout=10, persist=True)
+
+    assert out == fake
+    assert (tmp_path / "cookies.json").exists()
+
+
+def test_login_via_qr_success_no_persist(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOOFISH_COOKIES_PATH", str(tmp_path / "cookies.json"))
+    fake = {"_m_h5_tk": "t", "unb": "u", "cookie2": "c"}
+    with patch.object(qr_login, "asyncio") as mock_async:
+        mock_async.run.side_effect = _fake_run(fake)
+        out = qr_login.login_via_qr(timeout=10, persist=False)
+
+    assert out == fake
+    assert not (tmp_path / "cookies.json").exists()
+
+
+def test_login_via_qr_timeout_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOOFISH_COOKIES_PATH", str(tmp_path / "cookies.json"))
+    with patch.object(qr_login, "asyncio") as mock_async:
+        mock_async.run.side_effect = _fake_run({})  # 模拟超时没拿到 cookies
+        out = qr_login.login_via_qr(timeout=5, persist=True)
+
+    assert out == {}
+    # 空结果不应写盘
+    assert not (tmp_path / "cookies.json").exists()
+
+
+def test_login_via_qr_swallows_playwright_exception():
+    with patch.object(qr_login, "asyncio") as mock_async:
+        mock_async.run.side_effect = _fake_run_raises(RuntimeError("chrome not installed"))
+        out = qr_login.login_via_qr(timeout=5, persist=False)
+    assert out == {}
+
+
+def test_login_via_qr_respects_env_timeout(monkeypatch):
+    """timeout=None 时读 GOOFISH_QR_TIMEOUT，传给 _login_via_qr_async。"""
+    monkeypatch.setenv("GOOFISH_QR_TIMEOUT", "30")
+    captured: list[int] = []
+
+    async def _record(t):
+        captured.append(t)
+        return {}
+
+    monkeypatch.setattr(qr_login, "_login_via_qr_async", _record)
+    out = qr_login.login_via_qr(persist=False)
+
+    assert captured == [30]
+    assert out == {}
+
+
+@pytest.mark.parametrize(
+    "cookies,expected",
+    [
+        ([{"name": "_m_h5_tk", "value": "a"},
+          {"name": "unb", "value": "b"},
+          {"name": "cookie2", "value": "c"}], True),
+        ([{"name": "_m_h5_tk", "value": "a"},
+          {"name": "unb", "value": "b"}], False),  # 缺 cookie2
+        ([{"name": "_m_h5_tk", "value": "a"},
+          {"name": "unb", "value": ""},  # unb 为空等于没有
+          {"name": "cookie2", "value": "c"}], False),
+        ([], False),
+    ],
+)
+def test_has_all_login_cookies(cookies, expected):
+    assert qr_login._has_all_login_cookies(cookies) is expected

--- a/uv.lock
+++ b/uv.lock
@@ -307,7 +307,7 @@ wheels = [
 
 [[package]]
 name = "goofish-cli"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },


### PR DESCRIPTION
## Summary
- **新增 `auth login --qr` 扫码登录**（`core/qr_login.py`）——v0.2.3 的"快速进入"免密登录依赖浏览器免密记忆，换机 / 清 cookie / 长期不登 / 首次用都会失效，本 PR 补扫码路径作为兜底。
- passport iframe（`styleType=vertical`）的 QR canvas 首屏就在 DOM 里，无需切 tab；轮询 `context.cookies()` 直到见到完整 session cookie（`_m_h5_tk / unb / cookie2`）即判成功，抓快照写盘。
- 与 v0.2.3 refresh 分工清晰：refresh=无感续命（SESSION_EXPIRED 时自动点"快速进入"）、qr_login=显式扫码（需用户拿手机）。**不**把 QR 塞进 refresh 自动 retry，因为扫码时间不可控，会违反"无感"语义。

## 关键实现点
- `goofish_page(cookies={})` 必须传**空 dict**——不传会走 `Session.load()` 把旧登录态灌进去，passport 优先走"快速进入"跳过 QR，用户看不到扫码界面。
- `--qr` 与 `<source>` / `--raw` / `--browser` 互斥（QR 走独立 Playwright 浏览器，组合使用会让用户困惑"我传的 cookie 哪去了？"）。
- `GOOFISH_QR_TIMEOUT=N` / `--qr-timeout N`（默认 120s）可调；超时抛 `AuthRequiredError` 并提示延长超时重试。

## Test plan
- [x] 新增 9 个单测覆盖：成功写盘 / 不写盘 / 超时 / Playwright 异常 / env 覆盖超时 / 完整 cookies 校验参数化
- [x] 全量 94 个测试通过，ruff lint clean
- [x] **真实 E2E**：本机 headful Chrome 跑 `goofish auth login --qr --qr-timeout 180`，59s 完成扫码 + 手机确认，passport 下发 25 个 cookie，`auth status` 从 invalid → valid