### PR TITLE
feat(security): encrypt cookie storage with Fernet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "websockets>=13",
   "browser-cookie3>=0.20",
   "playwright>=1.58.0",
+  "cryptography>=41.0",
 ]
 
 [project.optional-dependencies]

--- a/src/goofish_cli/core/crypto.py
+++ b/src/goofish_cli/core/crypto.py
@@ -1,0 +1,35 @@
+"""Cookie 加密存储。Fernet (AES-128-CBC + HMAC-SHA256) + PBKDF2 机器密钥。
+
+密钥从 hostname + username 派生，无需用户输入密码。
+同一机器每次派生相同密钥，跨机器密钥不同（cookie 文件不可迁移）。
+"""
+from __future__ import annotations
+
+import getpass
+import hashlib
+import json
+import platform
+
+from cryptography.fernet import Fernet, InvalidToken
+
+_SALT = b"goofish-cli-cookie-enc-v1"
+_ITERATIONS = 480_000
+
+
+def _machine_key() -> bytes:
+    raw = f"{platform.node()}:{getpass.getuser()}:goofish-cli".encode()
+    dk = hashlib.pbkdf2_hmac("sha256", raw, _SALT, _ITERATIONS)
+    return __import__("base64").urlsafe_b64encode(dk)
+
+
+def encrypt_cookies(cookies: dict[str, str]) -> bytes:
+    payload = json.dumps(cookies, ensure_ascii=False).encode()
+    return Fernet(_machine_key()).encrypt(payload)
+
+
+def decrypt_cookies(data: bytes) -> dict[str, str]:
+    try:
+        plain = Fernet(_machine_key()).decrypt(data)
+    except InvalidToken as e:
+        raise ValueError("cookie 解密失败（可能在其他机器上加密的）") from e
+    return json.loads(plain)

--- a/src/goofish_cli/core/session.py
+++ b/src/goofish_cli/core/session.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import requests
 from loguru import logger
 
+from goofish_cli.core.crypto import decrypt_cookies, encrypt_cookies
 from goofish_cli.core.errors import AuthRequiredError
 from goofish_cli.core.sign import generate_device_id
 
@@ -76,7 +77,10 @@ class Session:
 def _load_or_bootstrap_cookies(path: Path) -> dict[str, str]:
     """先查本地 cookies.json；没有就从本机浏览器自动导入一次写盘。"""
     if path.exists():
-        return _load_cookies(path)
+        cookies = _load_cookies(path)
+        # 明文旧文件 → 自动加密覆盖
+        _maybe_migrate_to_encrypted(path, cookies)
+        return cookies
 
     # 本地不存在，走自动 bootstrap（除非用户显式关闭）
     if os.environ.get("GOOFISH_NO_CHROME_BOOTSTRAP") == "1":
@@ -117,13 +121,9 @@ def _bootstrap_from_browser() -> tuple[str, dict[str, str]]:
 
 
 def write_cookies_json(path: Path, cookies: dict[str, str]) -> None:
-    """把 cookies dict 以 Chrome 扩展风格 JSON 数组落盘。供 auth login 复用。"""
+    """把 cookies dict 加密落盘。供 auth login / refresh / qr_login 复用。"""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(
-        [{"name": k, "value": v} for k, v in cookies.items()],
-        ensure_ascii=False,
-        indent=2,
-    ))
+    path.write_bytes(encrypt_cookies(cookies))
     path.chmod(0o600)
 
 
@@ -149,11 +149,33 @@ def _load_or_mint_device_id(unb: str) -> str:
 
 
 def _load_cookies(path: Path) -> dict[str, str]:
-    text = path.read_text()
-    raw = json.loads(text)
-    # 兼容两种格式：Chrome 扩展导出的 list[{name,value,...}] / 纯 dict
+    raw_bytes = path.read_bytes()
+    # 优先尝试加密格式解密
+    try:
+        return decrypt_cookies(raw_bytes)
+    except (ValueError, Exception):  # noqa: BLE001
+        pass
+    # fallback: 明文 JSON（兼容旧版本或手动导出的文件）
+    try:
+        raw = json.loads(raw_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        raise AuthRequiredError(f"cookie 文件格式不识别（非加密也非 JSON）：{path}") from e
     if isinstance(raw, list):
         return {c["name"]: c["value"] for c in raw if "name" in c and "value" in c}
     if isinstance(raw, dict):
         return {str(k): str(v) for k, v in raw.items()}
     raise AuthRequiredError(f"cookies.json 格式不识别：{path}")
+
+
+def _maybe_migrate_to_encrypted(path: Path, cookies: dict[str, str]) -> None:
+    """如果文件是明文 JSON，自动加密覆盖。"""
+    try:
+        raw = path.read_bytes()
+        json.loads(raw)  # 能 parse 说明是明文
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return  # 已经是加密格式，无需迁移
+    try:
+        write_cookies_json(path, cookies)
+        logger.info(f"已将明文 cookie 自动加密 → {path}")
+    except OSError as e:
+        logger.debug(f"自动加密迁移失败（不影响使用）：{e}")

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,41 @@
+"""Cookie 加密模块测试。"""
+from __future__ import annotations
+
+from goofish_cli.core.crypto import decrypt_cookies, encrypt_cookies
+
+
+def test_round_trip():
+    cookies = {"unb": "U123", "_m_h5_tk": "T_xxx_1", "tracknick": "test"}
+    encrypted = encrypt_cookies(cookies)
+    decrypted = decrypt_cookies(encrypted)
+    assert decrypted == cookies
+
+
+def test_different_ciphertext_each_time():
+    """相同明文每次加密应产生不同密文（随机 IV）。"""
+    cookies = {"unb": "U1"}
+    a = encrypt_cookies(cookies)
+    b = encrypt_cookies(cookies)
+    assert a != b
+    # 但都能正确解密
+    assert decrypt_cookies(a) == decrypt_cookies(b) == cookies
+
+
+def test_tampered_ciphertext_fails():
+    """篡改密文应解密失败。"""
+    encrypted = encrypt_cookies({"k": "v"})
+    tampered = encrypted[:-4] + b"xxxx"
+    try:
+        decrypt_cookies(tampered)
+        raise AssertionError("应该抛异常")
+    except ValueError:
+        pass
+
+
+def test_empty_dict():
+    assert decrypt_cookies(encrypt_cookies({})) == {}
+
+
+def test_unicode_values():
+    cookies = {"tracknick": "用户昵称"}
+    assert decrypt_cookies(encrypt_cookies(cookies)) == cookies

--- a/tests/test_session_bootstrap.py
+++ b/tests/test_session_bootstrap.py
@@ -10,6 +10,7 @@ import json
 import pytest
 
 from goofish_cli.core import session as session_mod
+from goofish_cli.core.crypto import decrypt_cookies
 from goofish_cli.core.errors import AuthRequiredError
 
 
@@ -58,10 +59,10 @@ def test_load_bootstraps_when_missing(fake_cookies_path, monkeypatch):
     s = session_mod.Session.load()
     assert s.unb == "U2"
     assert called["n"] == 1
-    # 写盘了
+    # 写盘了（加密格式）
     assert fake_cookies_path.exists()
-    data = json.loads(fake_cookies_path.read_text())
-    assert {"name": "unb", "value": "U2"} in data
+    data = decrypt_cookies(fake_cookies_path.read_bytes())
+    assert data["unb"] == "U2"
     # 文件权限 0o600
     assert (fake_cookies_path.stat().st_mode & 0o777) == 0o600
 
@@ -129,9 +130,37 @@ def test_load_raises_when_bootstrap_fail_does_not_write(fake_cookies_path, monke
 
 
 def test_write_cookies_json_format(tmp_path):
-    """write_cookies_json 应写 Chrome 扩展风格的 list。auth login 和 Session 都用同一个。"""
+    """write_cookies_json 应写加密格式，解密后内容正确。"""
     target = tmp_path / "out.json"
     session_mod.write_cookies_json(target, {"a": "1", "b": "2"})
-    data = json.loads(target.read_text())
-    assert data == [{"name": "a", "value": "1"}, {"name": "b", "value": "2"}]
+    raw = target.read_bytes()
+    # 加密文件不应是明文 JSON
+    with pytest.raises((json.JSONDecodeError, UnicodeDecodeError)):
+        json.loads(raw)
+    # 解密后内容正确
+    data = decrypt_cookies(raw)
+    assert data == {"a": "1", "b": "2"}
     assert (target.stat().st_mode & 0o777) == 0o600
+
+
+def test_plaintext_migration_to_encrypted(fake_cookies_path, monkeypatch):
+    """旧版明文 JSON 文件应被自动加密覆盖（向后兼容迁移）。"""
+    # 写入旧版明文格式
+    fake_cookies_path.write_text(json.dumps([
+        {"name": "unb", "value": "U1"},
+        {"name": "_m_h5_tk", "value": "T_xxx_1"},
+    ]))
+    # 确认当前是明文
+    assert fake_cookies_path.read_text().startswith("[")
+
+    monkeypatch.setattr(session_mod, "_bootstrap_from_browser", lambda: (_ for _ in ()).throw(AssertionError("不该触发")))
+
+    s = session_mod.Session.load()
+    assert s.unb == "U1"
+
+    # 文件已被加密
+    raw = fake_cookies_path.read_bytes()
+    with pytest.raises((json.JSONDecodeError, UnicodeDecodeError)):
+        json.loads(raw)
+    data = decrypt_cookies(raw)
+    assert data["unb"] == "U1"

--- a/uv.lock
+++ b/uv.lock
@@ -311,6 +311,7 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },
+    { name = "cryptography" },
     { name = "loguru" },
     { name = "mcp" },
     { name = "playwright" },
@@ -335,6 +336,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "browser-cookie3", specifier = ">=0.20" },
+    { name = "cryptography", specifier = ">=41.0" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "mcp", specifier = ">=1.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },


### PR DESCRIPTION
## Summary

- Cookie 文件从明文 JSON 改为 Fernet 加密存储（AES-128-CBC + HMAC-SHA256）
- 密钥通过 PBKDF2 从 `hostname + username` 派生，无需用户输入密码
- 向后兼容：旧版明文文件首次加载时自动加密迁移

## Motivation

`~/.goofish-cli/cookies.json` 存储完整的闲鱼/淘宝登录态，明文存储意味着任何能以当前用户身份运行的进程都可以读取。加密后即使文件被读取也无法直接获取 cookie 内容。

## Changes

| 文件 | 说明 |
|------|------|
| `src/goofish_cli/core/crypto.py` | **新增** — Fernet 加解密模块 |
| `src/goofish_cli/core/session.py` | `write_cookies_json()` 写入加密数据，`_load_cookies()` 解密读取 + 明文 fallback |
| `pyproject.toml` | 添加 `cryptography>=41.0` 依赖 |
| `tests/test_crypto.py` | **新增** — 5 个加解密测试 |
| `tests/test_session_bootstrap.py` | 适配加密格式 + 新增迁移测试 |

## Security Design

- **算法**: Fernet = AES-128-CBC + HMAC-SHA256（`cryptography` 库标准实现）
- **密钥派生**: PBKDF2-HMAC-SHA256, 480k iterations, salt = `b"goofish-cli-cookie-enc-v1"`
- **输入材料**: `platform.node() + getpass.getuser()` — 同机器同用户始终派生相同密钥
- **随机性**: 每次加密生成随机 IV，相同明文产生不同密文
- **防篡改**: Fernet 自带 HMAC 验证，篡改密文会解密失败

## Backward Compatibility

- 读取时先尝试 Fernet 解密，失败后 fallback 解析明文 JSON
- 首次加载明文旧文件后自动加密覆盖（静默迁移）
- `refresh.py` / `qr_login.py` / `auth/login.py` 无需修改（共享 `write_cookies_json`）

## Test Plan

- [x] `uv run pytest -q` — 110 passed
- [x] `uv run ruff check src tests` — All checks passed
- [x] 加密往返测试（加密→解密→内容一致）
- [x] 随机 IV 测试（相同明文不同密文）
- [x] 防篡改测试（修改密文→解密失败）
- [x] 明文迁移测试（旧文件→自动加密）

🤖 Generated with [Claude Code](https://claude.com/claude-code)