### PR TITLE
feat: publish goofish-cli as an OpenClaw plugin

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "goofish",
+  "version": "0.3.0",
+  "description": "Xianyu tools and operating skills backed by goofish-cli.",
+  "author": {
+    "name": "fancy",
+    "email": "saral96@mail.com",
+    "url": "https://github.com/fancyboi999"
+  },
+  "homepage": "https://github.com/fancyboi999/goofish-cli",
+  "repository": "https://github.com/fancyboi999/goofish-cli",
+  "license": "Apache-2.0",
+  "keywords": [
+    "xianyu",
+    "goofish",
+    "mcp",
+    "openclaw"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Goofish",
+    "shortDescription": "Operate a Xianyu shop with guarded MCP tools.",
+    "longDescription": "Inspect, publish, diagnose, and reply on Xianyu through goofish-cli MCP tools and task-specific skills.",
+    "developerName": "fancy",
+    "category": "Productivity",
+    "capabilities": [
+      "MCP tools",
+      "Skills"
+    ],
+    "websiteURL": "https://github.com/fancyboi999/goofish-cli",
+    "defaultPrompt": [
+      "Check my Xianyu shop status and identify any risks.",
+      "Help me prepare a Xianyu listing for review.",
+      "Review unread buyer messages and draft replies."
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,13 @@ jobs:
         with:
           name: dist
           path: dist/
+
+  openclaw-plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Validate OpenClaw plugin package
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ Thumbs.db
 /frames.jsonl
 /ws_diag*.jsonl
 .video-build/
+
+# npm / ClawHub package artifacts
+*.tgz

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,24 @@
+{
+  "mcpServers": {
+    "goofish": {
+      "transport": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "goofish-cli==0.3.0",
+        "goofish-cli"
+      ],
+      "connectionTimeoutMs": 120000,
+      "requestTimeoutMs": 120000,
+      "supportsParallelToolCalls": false,
+      "toolFilter": {
+        "exclude": [
+          "auth_login",
+          "auth_reset_guard",
+          "message_watch",
+          "skills_install"
+        ]
+      }
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- OpenClaw / ClawHub compatible bundle metadata. The bundle contributes the existing five skills
+  and launches the pinned `goofish-cli` MCP server through `uvx` on OpenClaw 2026.6.1 or newer.
+- OpenClaw package checks covering version alignment, MCP safety filters, package contents, and
+  secret-bearing path exclusions.
+
+### Changed
+- Goofish skills now document both OpenClaw (`goofish__*`) and Claude
+  (`mcp__goofish__*`) MCP tool names.
+
 ## [0.3.0] - 2026-04-22
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,26 @@ sudo apt install nodejs # Debian/Ubuntu
 ```bash
 uv run pytest
 uv run ruff check src tests
+npm test
+npm run pack:check
 ```
+
+改动 OpenClaw bundle 时还要用隔离配置做一次 link 或打包后的 `.tgz` archive 安装，确认
+`openclaw plugins inspect goofish --json` 能识别 skills 和 MCP server。OpenClaw
+`2026.7.1` 的 `mcp doctor` 不读取 bundle MCP 配置，不能代替这个检查。
+发布 ClawHub bundle 前必须先在 PyPI 发布同版本 `goofish-cli`，并实际运行
+`uvx --from goofish-cli==<version> goofish-cli` 完成 MCP handshake；`.mcp.json`
+故意精确锁定两个包的版本，不会自动回退到旧版 Python 运行时。
+用 ClawHub CLI 发布时要显式指定 bundle family：
+
+```bash
+npm pack
+clawhub package publish ./openclaw-goofish-<version>.tgz \
+  --family bundle-plugin --bundle-format codex --host-targets openclaw --dry-run
+```
+
+`openclaw.plugin.json` 只提供 ClawHub 包身份和空配置 schema；实际运行入口仍是
+`.codex-plugin/plugin.json` 和 `.mcp.json`，`package.json` 不得增加 `openclaw.extensions`。
 
 单测全绿 **不等于** 功能可用。下面三种情况是硬门槛：
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,10 @@ clawhub package publish ./openclaw-goofish-<version>.tgz \
 
 `openclaw.plugin.json` 只提供 ClawHub 包身份和空配置 schema；实际运行入口仍是
 `.codex-plugin/plugin.json` 和 `.mcp.json`，`package.json` 不得增加 `openclaw.extensions`。
+工具过滤必须通过 `openclaw agent --local` 的 embedded-agent 会话 trajectory 验证；
+`openclaw mcp probe` 不读取 bundle 的 `.mcp.json`，不能作为 bundle E2E 证据。
+预期为 13 个业务工具可见，4 个 `toolFilter.exclude` 工具不可见；OpenClaw
+另外生成的 4 个 prompts/resources 桥接工具不计入业务工具数。
 
 单测全绿 **不等于** 功能可用。下面三种情况是硬门槛：
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@
 -->
 
 `goofish-cli` 把闲鱼（Xianyu/Goofish）的核心运营能力抽成一套结构化命令，
-**同一份定义**同时输出给三种消费者：
+**同一份定义**同时输出给四种消费者：
 
 - 👨‍💻 **人类**：`goofish item get 12345 --format table`
 - 🤖 **AI Agent（Claude Code / Cursor / Codex）**：`uvx goofish-cli` → 自动注册成 MCP tool
 - 🧩 **Claude Skills**（v0.3）：5 个内置 skill，`goofish skills install` 一行装到 `~/.claude/skills/`
+- **OpenClaw**：ClawHub bundle 一次安装 MCP server + 5 个 skills
 
 > 架构思想来自 [opencli](https://github.com/jackwener/opencli) 的 single-registry 设计。
 
@@ -44,7 +45,7 @@
 
 ## ✨ 核心特性
 
-- 🔐 **16 个命令覆盖核心链路**：发布、下架、查询、图片上传、AI 类目识别、默认地址、IM 收发 + 会话列表、skills 安装
+- 🔐 **17 个命令覆盖核心链路**：发布、下架、查询、图片上传、AI 类目识别、默认地址、IM 收发 + 会话列表、skills 安装
 - 📡 **真·实时 IM**：WebSocket 长连 + 自动重连 + **三类事件分类输出**
   - `event=message`（收到消息）· `event=read`（已读回执）· `event=new_msg`（轻量通知）
 - 🛡 **内置风控护栏**：令牌桶限流（1 写/分钟）+ RGV587 自动熔断
@@ -107,6 +108,36 @@ skill 的源文件在仓库的 `skills/` 目录下（每个 skill 一个子目�
 ```bash
 claude /plugin marketplace add fancyboi999/goofish-cli
 ```
+
+---
+
+## OpenClaw / ClawHub
+
+OpenClaw `2026.6.1` 及以上可把本仓库作为 compatible bundle 加载。ClawHub 发布后：
+
+```bash
+openclaw plugins install clawhub:openclaw-goofish
+
+# 登录态由用户在终端初始化，不交给 Agent 覆盖
+uvx --from goofish-cli==0.3.0 goofish auth login --qr
+
+openclaw plugins inspect goofish --json
+openclaw gateway restart
+```
+
+本地开发无需发布：
+
+```bash
+openclaw plugins install -l .
+openclaw plugins inspect goofish --json
+```
+
+重启后新会话会获得 5 个 skills，以及 `goofish__auth_status`、
+`goofish__item_get` 等 MCP tools。bundle 默认不暴露需要操作者执行或会长期阻塞的
+`auth_login`、`auth_reset_guard`、`message_watch`、`skills_install`。
+
+运行 MCP server 需要 PATH 中有 [`uv`](https://docs.astral.sh/uv/)。完整说明见
+[MCP 接入指南](./docs/mcp-setup.md)。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ goofish auth login ~/Downloads/goofish-cookies.json
 
 # 3. 验证登录态
 goofish auth status
-# → {"unb":"2214350705775","tracknick":"xy575986224572","nick":"...","valid":true}
+# → {"unb":"<masked-unb>","tracknick":"<masked-tracknick>","nick":"...","valid":true}
 
 # 4. 干活
 goofish item get 1045171414271
@@ -175,8 +175,8 @@ $ goofish list-commands --format table
 
 ```json
 {
-  "unb": "2214350705775",
-  "tracknick": "xy575986224572",
+  "unb": "<masked-unb>",
+  "tracknick": "<masked-tracknick>",
   "nick": "闲鱼用户昵称",
   "valid": true,
   "h5_token_exp": "2026-04-21T20:30:00+08:00"
@@ -194,10 +194,10 @@ $ goofish message watch
 实时输出（小号给主号发 3 条 + 主号读了所有消息）：
 
 ```jsonl
-{"event":"message","cid":"60585751957","send_user_id":"2215266653893","send_user_name":"小号昵称","send_message":"测试消息1"}
-{"event":"message","cid":"60585751957","send_user_id":"2215266653893","send_user_name":"小号昵称","send_message":"测试消息2"}
-{"event":"message","cid":"60585751957","send_user_id":"2215266653893","send_user_name":"小号昵称","send_message":"测试消息3"}
-{"event":"read","cid":"60585751957","msg_ids":["4077151826249.PNM","4066820235744.PNM","4066826134477.PNM"],"status":1,"ts":"1776770953455"}
+{"event":"message","cid":"<masked-cid>","send_user_id":"<masked-user-id>","send_user_name":"小号昵称","send_message":"测试消息1"}
+{"event":"message","cid":"<masked-cid>","send_user_id":"<masked-user-id>","send_user_name":"小号昵称","send_message":"测试消息2"}
+{"event":"message","cid":"<masked-cid>","send_user_id":"<masked-user-id>","send_user_name":"小号昵称","send_message":"测试消息3"}
+{"event":"read","cid":"<masked-cid>","msg_ids":["<masked-msg-id-1>","<masked-msg-id-2>","<masked-msg-id-3>"],"status":1,"ts":"<masked-timestamp>"}
 ```
 
 | 事件 | 字段 |
@@ -213,12 +213,12 @@ $ goofish message watch
 <summary><b><code>goofish message send</code></b> — 主动发消息</summary>
 
 ```bash
-$ goofish message send 60585751957 2215266653893 \
+$ goofish message send <masked-cid> <masked-user-id> \
     --text "在的 claude 测试成功 ✅" --item-id 1045171414271
 ```
 
 ```json
-{"ok": true, "mid": "1061776769407570", "cid": "60585751957"}
+{"ok": true, "mid": "<masked-message-id>", "cid": "<masked-cid>"}
 ```
 </details>
 

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -1,6 +1,43 @@
 # MCP 接入指南
 
-## Claude Code / Codex CLI
+## OpenClaw / ClawHub
+
+要求：OpenClaw `2026.6.1` 及以上，且 PATH 中可以执行 `uvx`。
+
+ClawHub 发布后安装：
+
+```bash
+openclaw plugins install clawhub:openclaw-goofish
+uvx --from goofish-cli==0.3.0 goofish auth login --qr
+openclaw plugins inspect goofish --json
+openclaw gateway restart
+```
+
+本地开发使用 link 安装：
+
+```bash
+openclaw plugins install -l /path/to/goofish-cli
+openclaw plugins inspect goofish --json
+```
+
+`inspect` 应显示 `Format: bundle`、Codex subtype，以及 skills 和 MCP server 能力。
+Gateway 重启后新会话中，工具名为 `goofish__<逻辑名>`，例如
+`goofish__auth_status` 和 `goofish__item_get`。
+
+bundle 默认过滤以下工具：
+
+| 工具 | 原因 |
+|---|---|
+| `auth_login` | 会覆盖磁盘登录态，应由用户在终端执行 |
+| `auth_reset_guard` | 恢复动作需要用户判断，且不能解除服务端风控 |
+| `message_watch` | 常驻阻塞式连接，不适合作为单次 Agent tool |
+| `skills_install` | bundle 已直接提供 skills，无需 Agent 再安装 |
+
+OpenClaw `2026.7.1` 的 `openclaw mcp doctor` 只读取 `openclaw.json` 中的
+`mcp.servers`，不会读取 bundle 的 `.mcp.json`；因此插件验收应使用 `plugins inspect`
+和新会话工具目录，不要重复配置同一个 server 只为运行 doctor。
+
+## Claude Code
 
 在 `~/.claude/settings.json` 或项目 `.claude/settings.json` 加：
 
@@ -33,7 +70,8 @@
 
 ## 可用工具
 
-启动后 Claude 获得以下 tool：
+启动后 Claude 获得以下 tool；skills 中使用 Claude 的
+`mcp__goofish__<逻辑名>` 前缀：
 
 | Tool 名 | 说明 |
 |---|---|

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -35,7 +35,11 @@ bundle 默认过滤以下工具：
 
 OpenClaw `2026.7.1` 的 `openclaw mcp doctor` 只读取 `openclaw.json` 中的
 `mcp.servers`，不会读取 bundle 的 `.mcp.json`；因此插件验收应使用 `plugins inspect`
-和新会话工具目录，不要重复配置同一个 server 只为运行 doctor。
+和 embedded agent 新会话的 trajectory 工具目录，不要重复配置同一个 server
+只为运行 doctor。验收时应看到 13 个 Goofish 业务工具，且不应看到上表的
+4 个过滤工具。OpenClaw 还会为 MCP prompts/resources 生成
+`goofish__prompts_*` 和 `goofish__resources_*` 4 个桥接工具，因此按
+`goofish__*` 前缀统计的总数是 17，不代表 `toolFilter` 失效。
 
 ## Claude Code
 

--- a/openclaw-plugin/package.test.mjs
+++ b/openclaw-plugin/package.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const bundleManifest = JSON.parse(
+  readFileSync(new URL("../.codex-plugin/plugin.json", import.meta.url), "utf8"),
+);
+const mcpConfig = JSON.parse(
+  readFileSync(new URL("../.mcp.json", import.meta.url), "utf8"),
+);
+const openClawManifest = JSON.parse(
+  readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+);
+const pyproject = readFileSync(new URL("../pyproject.toml", import.meta.url), "utf8");
+const overviewSkill = readFileSync(
+  new URL("../skills/goofish-overview/SKILL.md", import.meta.url),
+  "utf8",
+);
+
+test("keeps the OpenClaw package aligned with goofish-cli", () => {
+  const pythonVersion = pyproject.match(/^version = "([^"]+)"$/m)?.[1];
+  assert.equal(packageJson.version, pythonVersion);
+  assert.equal(bundleManifest.version, pythonVersion);
+  assert.equal(openClawManifest.version, pythonVersion);
+  assert.equal(openClawManifest.id, "goofish");
+  assert.deepEqual(openClawManifest.configSchema, {
+    type: "object",
+    additionalProperties: false,
+    properties: {},
+  });
+  assert.equal(bundleManifest.name, "goofish");
+  assert.equal(bundleManifest.skills, "./skills/");
+  assert.equal(bundleManifest.mcpServers, "./.mcp.json");
+  assert.equal(bundleManifest.author.name, "fancy");
+  assert.equal(bundleManifest.interface.displayName, "Goofish");
+  assert.ok(Array.isArray(bundleManifest.interface.defaultPrompt));
+  assert.ok(bundleManifest.interface.defaultPrompt.length > 0);
+  assert.equal(packageJson.openclaw.extensions, undefined);
+  assert.equal(packageJson.openclaw.install.clawhubSpec, "clawhub:openclaw-goofish");
+  assert.equal(packageJson.openclaw.install.defaultChoice, "clawhub");
+  assert.equal(packageJson.openclaw.install.minHostVersion, ">=2026.6.1");
+  assert.equal(packageJson.openclaw.compat.pluginApi, ">=2026.6.1");
+  assert.equal(packageJson.peerDependenciesMeta.openclaw.optional, true);
+  assert.ok(packageJson.openclaw.release.publishToClawHub);
+
+  const server = mcpConfig.mcpServers.goofish;
+  assert.equal(server.command, "uvx");
+  assert.deepEqual(server.args, ["--from", `goofish-cli==${pythonVersion}`, "goofish-cli"]);
+  assert.equal(server.supportsParallelToolCalls, false);
+  assert.deepEqual(server.toolFilter.exclude.toSorted(), [
+    "auth_login",
+    "auth_reset_guard",
+    "message_watch",
+    "skills_install",
+  ]);
+});
+
+test("documents host-specific MCP tool names", () => {
+  assert.match(overviewSkill, /goofish__auth_status/);
+  assert.match(overviewSkill, /mcp__goofish__auth_status/);
+});
+
+test("packs only the OpenClaw bundle metadata, docs, and skills", () => {
+  const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+    cwd: new URL("..", import.meta.url),
+    encoding: "utf8",
+  });
+  const packed = JSON.parse(output)[0];
+  const files = new Set(packed.files.map((entry) => entry.path));
+
+  for (const required of [
+    "package.json",
+    ".codex-plugin/plugin.json",
+    ".mcp.json",
+    "openclaw.plugin.json",
+    "docs/mcp-setup.md",
+    "skills/goofish-overview/SKILL.md",
+  ]) {
+    assert.ok(files.has(required), `missing packed file: ${required}`);
+  }
+
+  for (const entry of files) {
+    assert.ok(!entry.startsWith("src/"), `Python source leaked into plugin package: ${entry}`);
+    assert.ok(!entry.startsWith("tests/"), `Python tests leaked into plugin package: ${entry}`);
+    assert.ok(!entry.includes("cookie"), `cookie-bearing path leaked into package: ${entry}`);
+  }
+});

--- a/openclaw-plugin/package.test.mjs
+++ b/openclaw-plugin/package.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
@@ -63,27 +65,46 @@ test("documents host-specific MCP tool names", () => {
 });
 
 test("packs only the OpenClaw bundle metadata, docs, and skills", () => {
-  const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
-    cwd: new URL("..", import.meta.url),
-    encoding: "utf8",
-  });
-  const packed = JSON.parse(output)[0];
-  const files = new Set(packed.files.map((entry) => entry.path));
+  const packDirectory = mkdtempSync(join(tmpdir(), "openclaw-goofish-pack-"));
+  const repository = new URL("..", import.meta.url);
 
-  for (const required of [
-    "package.json",
-    ".codex-plugin/plugin.json",
-    ".mcp.json",
-    "openclaw.plugin.json",
-    "docs/mcp-setup.md",
-    "skills/goofish-overview/SKILL.md",
-  ]) {
-    assert.ok(files.has(required), `missing packed file: ${required}`);
-  }
+  try {
+    const output = execFileSync(
+      "npm",
+      ["pack", "--json", "--pack-destination", packDirectory],
+      { cwd: repository, encoding: "utf8" },
+    );
+    const packed = JSON.parse(output)[0];
+    const archive = join(packDirectory, packed.filename);
+    const files = new Set(packed.files.map((entry) => entry.path));
 
-  for (const entry of files) {
-    assert.ok(!entry.startsWith("src/"), `Python source leaked into plugin package: ${entry}`);
-    assert.ok(!entry.startsWith("tests/"), `Python tests leaked into plugin package: ${entry}`);
-    assert.ok(!entry.includes("cookie"), `cookie-bearing path leaked into package: ${entry}`);
+    for (const required of [
+      "package.json",
+      ".codex-plugin/plugin.json",
+      ".mcp.json",
+      "openclaw.plugin.json",
+      "docs/mcp-setup.md",
+      "skills/goofish-overview/SKILL.md",
+    ]) {
+      assert.ok(files.has(required), `missing packed file: ${required}`);
+    }
+
+    const sensitiveValue =
+      /["'](?:unb|tracknick|cid|toid|send_user_id|mid|msg_id)["']\s*:\s*["'](?!<masked-)[^"']{6,}["']/;
+    const rawMessageId = /\b\d{10,}\.PNM\b/;
+
+    for (const entry of files) {
+      assert.ok(!entry.startsWith("src/"), `Python source leaked into plugin package: ${entry}`);
+      assert.ok(!entry.startsWith("tests/"), `Python tests leaked into plugin package: ${entry}`);
+      assert.ok(!entry.includes("cookie"), `cookie-bearing path leaked into package: ${entry}`);
+
+      const content = execFileSync("tar", ["-xOf", archive, `package/${entry}`], {
+        encoding: "utf8",
+      });
+      assert.doesNotMatch(content, sensitiveValue, `account identifier leaked in ${entry}`);
+      assert.doesNotMatch(content, rawMessageId, `message identifier leaked in ${entry}`);
+    }
+  } finally {
+    rmSync(packDirectory, { recursive: true, force: true });
   }
 });

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "goofish",
+  "name": "Goofish",
+  "description": "ClawHub package identity for the Goofish compatible bundle.",
+  "version": "0.3.0",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "openclaw-goofish",
+  "version": "0.3.0",
+  "description": "OpenClaw plugin for goofish-cli MCP tools and Xianyu operation skills.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fancyboi999/goofish-cli.git"
+  },
+  "homepage": "https://github.com/fancyboi999/goofish-cli",
+  "bugs": {
+    "url": "https://github.com/fancyboi999/goofish-cli/issues"
+  },
+  "keywords": [
+    "openclaw",
+    "clawhub",
+    "xianyu",
+    "goofish",
+    "mcp"
+  ],
+  "files": [
+    ".codex-plugin/plugin.json",
+    ".mcp.json",
+    "openclaw.plugin.json",
+    "CHANGELOG.md",
+    "LICENSE",
+    "NOTICE",
+    "README.md",
+    "docs",
+    "skills"
+  ],
+  "scripts": {
+    "test": "node --test openclaw-plugin/package.test.mjs",
+    "pack:check": "npm pack --dry-run"
+  },
+  "engines": {
+    "node": ">=22.22.3"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.6.1"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "install": {
+      "clawhubSpec": "clawhub:openclaw-goofish",
+      "defaultChoice": "clawhub",
+      "minHostVersion": ">=2026.6.1"
+    },
+    "compat": {
+      "pluginApi": ">=2026.6.1",
+      "minGatewayVersion": "2026.6.1"
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": false,
+      "bundleRuntimeDependencies": false
+    }
+  }
+}

--- a/skills/goofish-overview/SKILL.md
+++ b/skills/goofish-overview/SKILL.md
@@ -4,7 +4,7 @@ description: |
   闲鱼（goofish.com）自动化运营的总入口 skill。何时激活：用户首次提到
   闲鱼 / 咸鱼 / goofish / 二手交易 / 挂闲置 / 回买家消息 / 发商品到闲鱼，
   或用户询问本工具如何使用、有哪些能力、能做什么。本 skill 介绍 goofish-cli
-  的定位、账号模型、16 个 MCP 工具速查、风控底线，并指向其它专项 skill
+  的定位、账号模型、17 个 MCP 工具速查、风控底线，并指向其它专项 skill
   （goofish-publish-item / goofish-reply-buyer / goofish-risk-guard /
   goofish-shop-diagnosis）。
 metadata:
@@ -17,11 +17,18 @@ metadata:
 
 ## 这是什么
 
-`goofish-cli` 是一个 **Python CLI + MCP server + Claude Skills** 三合一工具包，
+`goofish-cli` 是一个 **Python CLI + MCP server + Agent Skills** 三合一工具包，
 让 AI Agent 能像熟练卖家一样操作闲鱼：发商品、回消息、查风控、诊断店铺。
 
-你（Agent）在 Claude Code / Cursor 里通过 MCP 看到的工具，都来自同一个
+你（Agent）在 OpenClaw / Claude Code / Cursor 里通过 MCP 看到的工具，都来自同一个
 `goofish` server（`FastMCP("goofish")`）。
+
+## 工具命名
+
+本文使用 registry 里的逻辑名（例如 `auth_status`）。实际调用时按宿主补前缀：
+
+- OpenClaw：`goofish__auth_status`
+- Claude Code / Cursor：`mcp__goofish__auth_status`
 
 ## 四个专项 Skill 的分工
 
@@ -39,7 +46,7 @@ metadata:
 
 ## 账号与登录态
 
-- 登录态由 `mcp__goofish__auth_status` 检查，返回 `{valid: bool}`。
+- 登录态由 `auth_status` 检查，返回 `{valid: bool}`。
 - 自动刷新链路已内置（v0.2.2 - v0.2.4）：token 过期自动续、session 过期
   自动点 passport "快速进入"、浏览器免密失效需用户 `goofish auth login --qr`。
 - **Agent 不应主动调 `auth_login`**，这是敏感命令（会覆盖磁盘 cookie）。
@@ -47,7 +54,7 @@ metadata:
   `goofish auth login --qr`。
 - 账号身份细节见 `references/accounts.md`。
 
-## 16 个 MCP 工具速查
+## 17 个 MCP 工具速查
 
 详单在 `references/mcp-tools-index.md`。读不读看任务：
 - 发商品 → 只需 `category_recommend / media_upload / location_default / item_publish`
@@ -57,8 +64,7 @@ metadata:
 - 下架/删除 → `item_delete`
 - skills 安装 → `skills_install`（辅助类工具，一般 Agent 不会直接调；由用户在终端跑）
 
-**工具命名**：MCP 注册为 `mcp__goofish__{namespace}_{name}` 下划线格式。
-例如 CLI 里的 `message list-chats` 在 MCP 是 `mcp__goofish__message_list_chats`。
+例如 CLI 的 `message list-chats` 对应逻辑名 `message_list_chats`，调用时使用上面的宿主前缀。
 
 ## 合规硬红线（本工具禁止协助）
 

--- a/skills/goofish-overview/references/accounts.md
+++ b/skills/goofish-overview/references/accounts.md
@@ -4,7 +4,7 @@
 
 - 磁盘：`~/.goofish-cli/cookies.json`（可通过 `GOOFISH_COOKIES_PATH` 覆盖）
 - 内存：`Session.http.cookies`（requests 的 CookieJar）
-- `mcp__goofish__auth_status` 返回 `{unb, tracknick, nick, valid, h5_token_exp}`
+- `auth_status` 返回 `{unb, tracknick, nick, valid, h5_token_exp}`
 
 ## 关键 cookie 字段
 

--- a/skills/goofish-overview/references/mcp-tools-index.md
+++ b/skills/goofish-overview/references/mcp-tools-index.md
@@ -1,26 +1,27 @@
-# MCP 工具速查（共 16 个）
+# MCP 工具速查（共 17 个）
 
-> 命名规则：`mcp__goofish__{namespace}_{name}`，CLI 的 kebab-case 在 MCP 里被转成 snake_case。
-> 例：CLI `goofish message list-chats` → MCP `mcp__goofish__message_list_chats`。
-> `goofish skills install` 也会被 registry 扫到并暴露为 `mcp__goofish__skills_install`，
+> 下表使用 registry 逻辑名。OpenClaw 调 `goofish__<逻辑名>`，Claude Code / Cursor
+> 调 `mcp__goofish__<逻辑名>`。例：CLI `goofish message list-chats` 的逻辑名是
+> `message_list_chats`。`goofish skills install` 也会被 registry 扫到并暴露为 `skills_install`，
 > 但它是给**用户在终端跑**的辅助命令，Agent 通常不主动调。
 
 ## Auth（3 个）
 
 | 工具 | 用途 | 何时调 | 副作用 |
 |---|---|---|---|
-| `mcp__goofish__auth_status` | 查登录态（返回 `{unb, tracknick, nick, valid, h5_token_exp}`） | 任何写操作前第一步 | 无 |
-| `mcp__goofish__auth_login` | 导入登录态（browser auto-detect / 指定源 / `--qr` 扫码） | **Agent 不主动调**，只建议用户手动执行 | 覆盖磁盘 cookies.json |
-| `mcp__goofish__auth_reset_guard` | 解本地熔断 | RGV587 触发后的恢复步骤之一，但**不解服务端风控** | 清 local guard 状态 |
+| `auth_status` | 查登录态（返回 `{unb, tracknick, nick, valid, h5_token_exp}`） | 任何写操作前第一步 | 无 |
+| `auth_login` | 导入登录态（browser auto-detect / 指定源 / `--qr` 扫码） | **Agent 不主动调**，只建议用户手动执行 | 覆盖磁盘 cookies.json |
+| `auth_reset_guard` | 解本地熔断 | RGV587 触发后的恢复步骤之一，但**不解服务端风控** | 清 local guard 状态 |
 
-## Item（4 个）
+## Item（5 个）
 
 | 工具 | 用途 | 典型入参 | 风险 |
 |---|---|---|---|
-| `mcp__goofish__item_get` | HTTP 视角拉详情（只读） | `item_id` | 无 |
-| `mcp__goofish__item_view` | 浏览器视角拉详情（字段更全、抗风控） | `item_id` | 触发 Playwright 启动 |
-| `mcp__goofish__item_publish` | 发布商品（自动类目+默认地址） | `title, desc, price, image_urls, cat_id?, addr?` | **写操作**，令牌桶 1 写/分钟 |
-| `mcp__goofish__item_delete` | 下架/删除商品 | `item_id` | **写操作** + 风控护栏 |
+| `item_get` | HTTP 视角拉详情（只读） | `item_id` | 无 |
+| `item_list` | 查看当前账号的在售商品 | `limit?` | 无 |
+| `item_view` | 浏览器视角拉详情（字段更全、抗风控） | `item_id` | 触发 Playwright 启动 |
+| `item_publish` | 发布商品（自动类目+默认地址） | `title, desc, price, image_urls, cat_id?, addr?` | **写操作**，令牌桶 1 写/分钟 |
+| `item_delete` | 下架/删除商品 | `item_id` | **写操作** + 风控护栏 |
 
 **发布前强依赖**：`category_recommend` 拿 catId、`media_upload` 拿 image_urls、`location_default` 兜底 addr。
 
@@ -28,25 +29,25 @@
 
 | 工具 | 用途 | 典型入参 | 备注 |
 |---|---|---|---|
-| `mcp__goofish__message_list_chats` | 会话列表（左栏） | `limit?, watch_secs?` | session.sync v3.0 是阉割版，默认会启 WebSocket 增量补齐 cid |
-| `mcp__goofish__message_history` | 某 cid 的历史消息（翻页到底） | `cid` | 拉上下文做意图分类用 |
-| `mcp__goofish__message_watch` | 常驻 IM 长连接，事件以 JSONL 输出 | `secs?` | 阻塞式；Skill 里慎用，短连接更合适 |
-| `mcp__goofish__message_send` | 发消息（text/image） | `cid, text` 或 `cid, image_url, w, h` | **写操作** + 外联词风控 |
+| `message_list_chats` | 会话列表（左栏） | `limit?, watch_secs?` | session.sync v3.0 是阉割版，默认会启 WebSocket 增量补齐 cid |
+| `message_history` | 某 cid 的历史消息（翻页到底） | `cid` | 拉上下文做意图分类用 |
+| `message_watch` | 常驻 IM 长连接，事件以 JSONL 输出 | `secs?` | 阻塞式；Skill 里慎用，短连接更合适 |
+| `message_send` | 发消息（text/image） | `cid, text` 或 `cid, image_url, w, h` | **写操作** + 外联词风控 |
 
 ## Category / Media / Search / Location（4 个）
 
 | 工具 | 用途 | 备注 |
 |---|---|---|
-| `mcp__goofish__category_recommend` | AI 识别类目（输入标题+图片返回 catId/catName） | 发布前必跑，类目错放会降权 |
-| `mcp__goofish__media_upload` | 上传图片到闲鱼 CDN | 返回 `{url, width, height}`，给 `item_publish` 直接用 |
-| `mcp__goofish__search_items` | 搜闲鱼商品（浏览器路径，抗风控） | 诊断限流时用"卖家视角 vs 买家视角"对比 |
-| `mcp__goofish__location_default` | 账号默认发布地址 | `item_publish` 不传 addr 时的兜底 |
+| `category_recommend` | AI 识别类目（输入标题+图片返回 catId/catName） | 发布前必跑，类目错放会降权 |
+| `media_upload` | 上传图片到闲鱼 CDN | 返回 `{url, width, height}`，给 `item_publish` 直接用 |
+| `search_items` | 搜闲鱼商品（浏览器路径，抗风控） | 诊断限流时用"卖家视角 vs 买家视角"对比 |
+| `location_default` | 账号默认发布地址 | `item_publish` 不传 addr 时的兜底 |
 
 ## Skills（1 个，辅助类）
 
 | 工具 | 用途 | 备注 |
 |---|---|---|
-| `mcp__goofish__skills_install` | 把内置 Claude Skills 复制到 `~/.claude/skills/`（或 `--dest`） | `--list` 仅列出、`--force` 覆盖已有；给**用户**在终端跑，Agent 一般不主动调 |
+| `skills_install` | 把内置 Claude Skills 复制到 `~/.claude/skills/`（或 `--dest`） | `--list` 仅列出、`--force` 覆盖已有；给**用户**在终端跑，Agent 一般不主动调 |
 
 ## 调用模式速记
 

--- a/skills/goofish-publish-item/SKILL.md
+++ b/skills/goofish-publish-item/SKILL.md
@@ -21,6 +21,12 @@ allowed-tools:
 
 # 闲鱼发商品
 
+## 工具命名
+
+正文使用 `auth_status` 这类逻辑名。OpenClaw 调 `goofish__<逻辑名>`；
+Claude Code / Cursor 调 `mcp__goofish__<逻辑名>`。frontmatter 的 `allowed-tools`
+保留 Claude 权限预批准格式，OpenClaw 不读取该字段。
+
 ## 触发姿势
 
 用户典型输入：
@@ -35,7 +41,7 @@ allowed-tools:
 ### Step 1 · 登录态自检（必做）
 
 ```
-调 mcp__goofish__auth_status
+调 auth_status
   valid=true → 继续
   valid=false → 不继续；告诉用户: "登录态失效了，请执行 goofish auth login（扫码走 --qr）"，停。
 ```
@@ -61,7 +67,7 @@ allowed-tools:
 ### Step 3 · 类目识别
 
 ```
-调 mcp__goofish__category_recommend(title=候选标题, images=[首图])
+调 category_recommend(title=候选标题, images=[首图])
   → 拿到 catId / catName
 ```
 
@@ -91,7 +97,7 @@ allowed-tools:
 
 ```
 for image in images:
-    调 mcp__goofish__media_upload(image)
+    调 media_upload(image)
     收集返回的 {url, width, height}
 
 检查:
@@ -120,7 +126,7 @@ for image in images:
 
 确认后：
 ```
-调 mcp__goofish__item_publish(
+调 item_publish(
     title=..., 
     desc=..., 
     price=..., 

--- a/skills/goofish-publish-item/references/category-selection.md
+++ b/skills/goofish-publish-item/references/category-selection.md
@@ -2,12 +2,12 @@
 
 ## 核心原则
 
-**不要猜类目**。`mcp__goofish__category_recommend` 接入的是淘系类目库，比人拍脑袋准。
+**不要猜类目**。`category_recommend` 接入的是淘系类目库，比人拍脑袋准。
 
 ## 调用姿势
 
 ```
-mcp__goofish__category_recommend(
+category_recommend(
     title="候选标题（尽量带品牌+核心词）",
     images=["首图URL"]
 )

--- a/skills/goofish-publish-item/references/image-checklist.md
+++ b/skills/goofish-publish-item/references/image-checklist.md
@@ -34,7 +34,7 @@
 
 ```
 for path_or_url in images:
-    result = mcp__goofish__media_upload(path_or_url)
+    result = media_upload(path_or_url)
     uploaded.append({
         "url": result["url"],
         "width": result["width"],

--- a/skills/goofish-reply-buyer/SKILL.md
+++ b/skills/goofish-reply-buyer/SKILL.md
@@ -20,6 +20,12 @@ allowed-tools:
 
 # 闲鱼回买家消息
 
+## 工具命名
+
+正文使用 `auth_status` 这类逻辑名。OpenClaw 调 `goofish__<逻辑名>`；
+Claude Code / Cursor 调 `mcp__goofish__<逻辑名>`。frontmatter 的 `allowed-tools`
+保留 Claude 权限预批准格式，OpenClaw 不读取该字段。
+
 ## 触发姿势
 
 用户典型输入：
@@ -48,13 +54,13 @@ allowed-tools:
 ### Step 1 · 登录态自检
 
 ```
-mcp__goofish__auth_status → valid=false 直接停，提示用户 auth login
+auth_status → valid=false 直接停，提示用户 auth login
 ```
 
 ### Step 2 · 拉未读会话
 
 ```
-mcp__goofish__message_list_chats(limit=20)
+message_list_chats(limit=20)
 ```
 
 返回会话列表，每项含 cid / 对方昵称 / 最后一条消息预览 / 未读数。
@@ -68,14 +74,14 @@ mcp__goofish__message_list_chats(limit=20)
 
 ```
 对每个选中的 cid:
-    mcp__goofish__message_history(cid=..., limit=20)
+    message_history(cid=..., limit=20)
 ```
 
 20 条基本够分类意图了。太长的会话（50+ 条）拉 30 条。
 
 **同时**（如果消息提到具体商品 ID）：
 ```
-mcp__goofish__item_get(item_id=...)  # 拿商品的最新状态，价格/标题/是否在售
+item_get(item_id=...)  # 拿商品的最新状态，价格/标题/是否在售
 ```
 
 ### Step 4 · 意图分类
@@ -121,7 +127,7 @@ mcp__goofish__item_get(item_id=...)  # 拿商品的最新状态，价格/标题/
 ### Step 7 · 发送
 
 ```
-mcp__goofish__message_send(cid=..., text="...")
+message_send(cid=..., text="...")
 ```
 
 成功后：

--- a/skills/goofish-risk-guard/SKILL.md
+++ b/skills/goofish-risk-guard/SKILL.md
@@ -20,6 +20,12 @@ allowed-tools:
 
 # 闲鱼风控预检
 
+## 工具命名
+
+正文使用 `auth_status` 这类逻辑名。OpenClaw 调 `goofish__<逻辑名>`；
+Claude Code / Cursor 调 `mcp__goofish__<逻辑名>`。frontmatter 的 `allowed-tools`
+保留 Claude 权限预批准格式，OpenClaw 不读取该字段。
+
 ## 定位
 
 这是 **被其它 skill 频繁调用的知识库型 skill**。Agent 读它的 references，不一定要调 MCP 工具。

--- a/skills/goofish-shop-diagnosis/SKILL.md
+++ b/skills/goofish-shop-diagnosis/SKILL.md
@@ -19,6 +19,12 @@ allowed-tools:
 
 # 闲鱼店铺诊断
 
+## 工具命名
+
+正文使用 `auth_status` 这类逻辑名。OpenClaw 调 `goofish__<逻辑名>`；
+Claude Code / Cursor 调 `mcp__goofish__<逻辑名>`。frontmatter 的 `allowed-tools`
+保留 Claude 权限预批准格式，OpenClaw 不读取该字段。
+
 ## 定位
 
 **纯读 skill**——诊断、不修。要修的话跳到 `goofish-publish-item`。
@@ -37,7 +43,7 @@ allowed-tools:
 ### Step 1 · 买家视角搜索自检
 
 ```
-mcp__goofish__search_items(
+search_items(
     keyword="<商品核心词>",  # 从用户描述或 item 标题提取
     # 可以按地理/价格 filter 更精准
 )
@@ -57,7 +63,7 @@ mcp__goofish__search_items(
 ### Step 2 · 拉自家商品详情
 
 ```
-mcp__goofish__item_view(item_id=<问题商品>)
+item_view(item_id=<问题商品>)
 ```
 
 对比：


### PR DESCRIPTION
## 改动描述

将现有 `goofish-cli` MCP server 和 5 个 skills 打包为可由 OpenClaw / ClawHub 安装的 Codex compatible bundle，不新增进程内 JavaScript runtime。

## 动机 / 关联 issue

Closes #15

目前 OpenClaw 用户需要分别配置 MCP server 和 skills。这个 bundle 用 `.codex-plugin/plugin.json` + `.mcp.json` 复用同版本 Python registry，并默认过滤应由操作者执行或会长期阻塞的 4 个 tools。`openclaw.plugin.json` 只作为 ClawHub 包身份/空 schema；`package.json` 不声明 `openclaw.extensions`，因此 OpenClaw 始终按 bundle 加载。

最低 OpenClaw 版本为 `2026.6.1`：该稳定版同时包含 bundle MCP 运行和 `toolFilter.include/exclude`。

## 改动类型

- [ ] bug 修复
- [x] 新功能
- [ ] 重构（不改变外部行为）
- [x] 文档
- [x] CI / 构建

## 验证

- [x] `pytest` 全绿：`124 passed in 1.73s`
- [x] `ruff check src tests` 无告警
- [ ] 真实 CLI 跑通：本 PR 未修改 HTTP/WebSocket 命令或闲鱼协议行为，不需要用真实账号/cookie 重跑写操作

```text
$ npm test
3 tests passed

$ npm run pack:check
openclaw-goofish-0.3.0.tgz
33 files, 61.0 kB packed, 138.7 kB unpacked

$ clawhub package publish openclaw-goofish-0.3.0.tgz \
    --family bundle-plugin --bundle-format codex --host-targets openclaw --dry-run --json
family: bundle-plugin
version: 0.3.0
files: 33
totalBytes: 60966

$ openclaw@2026.6.1 plugins inspect goofish --json
format: bundle
bundleFormat: codex
bundleCapabilities: [skills, mcpServers]
mcpServers: [{name: goofish, hasStdioTransport: true}]
diagnostics: []

$ openclaw@2026.6.1 skills list --json
5 goofish-* skills, all eligible

$ openclaw@2026.7.1-2 plugins inspect goofish --json
format: bundle
bundleFormat: codex
diagnostics: []

# Run from this repository's root. `goofish-pr16` is an arbitrary temporary
# profile name; its isolated state is ~/.openclaw-goofish-pr16/.
$ PROFILE=goofish-pr16
$ REPO="$PWD"
$ PACK_DIR="$(mktemp -d)"
$ npm pack --pack-destination "$PACK_DIR"
$ openclaw --profile "$PROFILE" plugins install \
    "$PACK_DIR/openclaw-goofish-0.3.0.tgz"
$ openclaw --profile "$PROFILE" plugins inspect goofish --json
source: ~/.openclaw-goofish-pr16/extensions/goofish
install.source: archive; format: bundle; diagnostics: []

# PyPI 0.3.0 is not published yet. Patch only the isolated installed copy to
# launch the MCP entrypoint from this same-version checkout.
$ MCP="$HOME/.openclaw-$PROFILE/extensions/goofish/.mcp.json"
$ jq --arg repo "$REPO" \
    '.mcpServers.goofish.command="uv" |
     .mcpServers.goofish.args=["run","--project",$repo,"goofish-cli"]' \
    "$MCP" > "$MCP.tmp" && mv "$MCP.tmp" "$MCP"

# Configure any working model/provider in this isolated profile first.
$ openclaw --profile "$PROFILE" configure
$ SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
$ openclaw --profile "$PROFILE" agent --local --agent main \
    --session-id "$SESSION_ID" --thinking off --json \
    --message 'Reply with exactly: archive bundle catalog captured'
runner: embedded; stopReason: stop

$ TRAJECTORY="$HOME/.openclaw-$PROFILE/agents/main/sessions/$SESSION_ID.trajectory.jsonl"
$ jq -r '.. | objects | .name? // empty' "$TRAJECTORY" |
    grep '^goofish__' | sort -u
17 total: 13 domain tools and 4 MCP prompt/resource bridge tools
$ jq -r '.. | objects | .name? // empty' "$TRAJECTORY" |
    grep -E '^goofish__(auth_login|auth_reset_guard|message_watch|skills_install)$'
<no output>
```

PyPI 0.3.0 尚未发布，因此 archive E2E 只在隔离安装副本中将 MCP command 指向同版本本地
checkout 后再运行上述 agent 命令；该替换只修改
`~/.openclaw-goofish-pr16/extensions/goofish/.mcp.json`，打包的 `.mcp.json` 仍精确锁定
`goofish-cli==0.3.0`。工具数来自
`~/.openclaw-goofish-pr16/agents/main/sessions/$SESSION_ID.trajectory.jsonl` 中的实际
tool snapshot，未使用不读取 bundle 配置的 `openclaw mcp probe`。

Codex plugin manifest validation passed. `git diff --check`, package-content checks, targeted secret-pattern scan, and autoreview also passed.

PyPI 当前最新仍是 `goofish-cli==0.2.4`，所以精确锁定的 `uvx --from goofish-cli==0.3.0 goofish-cli` 要在 0.3.0 发布后才能从 PyPI handshake。贡献文档已将“先发布同版本 Python 包，再发布 ClawHub bundle”设为硬门槛。

## 合规

- [x] 我确认没有把 cookie / _m_h5_tk / 任何账号敏感信息 commit 进代码或测试 fixture
- [x] 我确认本 PR 不会被用于欺诈、刷单、违反闲鱼用户协议等行为
