### PR TITLE
ci: block sensitive account identifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,16 @@ on:
     branches: [main]
 
 jobs:
+  sensitive-identifiers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Scan tracked files for account and conversation identifiers
+        run: python scripts/check_sensitive_identifiers.py
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: uv run pytest -q
 
   build:
-    needs: test
+    needs: [test, sensitive-identifiers]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ goofish auth login ~/Downloads/goofish-cookies.json
 
 # 3. 验证登录态
 goofish auth status
-# → {"unb":"2214350705775","tracknick":"xy575986224572","nick":"...","valid":true}
+# → {"unb":"<masked-unb>","tracknick":"<masked-tracknick>","nick":"...","valid":true}
 
 # 4. 干活
 goofish item get 1045171414271
@@ -144,8 +144,8 @@ $ goofish list-commands --format table
 
 ```json
 {
-  "unb": "2214350705775",
-  "tracknick": "xy575986224572",
+  "unb": "<masked-unb>",
+  "tracknick": "<masked-tracknick>",
   "nick": "闲鱼用户昵称",
   "valid": true,
   "h5_token_exp": "2026-04-21T20:30:00+08:00"
@@ -163,10 +163,10 @@ $ goofish message watch
 实时输出（小号给主号发 3 条 + 主号读了所有消息）：
 
 ```jsonl
-{"event":"message","cid":"60585751957","send_user_id":"2215266653893","send_user_name":"小号昵称","send_message":"测试消息1"}
-{"event":"message","cid":"60585751957","send_user_id":"2215266653893","send_user_name":"小号昵称","send_message":"测试消息2"}
-{"event":"message","cid":"60585751957","send_user_id":"2215266653893","send_user_name":"小号昵称","send_message":"测试消息3"}
-{"event":"read","cid":"60585751957","msg_ids":["4077151826249.PNM","4066820235744.PNM","4066826134477.PNM"],"status":1,"ts":"1776770953455"}
+{"event":"message","cid":"<masked-cid>","send_user_id":"<masked-user-id>","send_user_name":"小号昵称","send_message":"测试消息1"}
+{"event":"message","cid":"<masked-cid>","send_user_id":"<masked-user-id>","send_user_name":"小号昵称","send_message":"测试消息2"}
+{"event":"message","cid":"<masked-cid>","send_user_id":"<masked-user-id>","send_user_name":"小号昵称","send_message":"测试消息3"}
+{"event":"read","cid":"<masked-cid>","msg_ids":["<masked-msg-id-1>","<masked-msg-id-2>","<masked-msg-id-3>"],"status":1,"ts":"<masked-timestamp>"}
 ```
 
 | 事件 | 字段 |
@@ -182,12 +182,12 @@ $ goofish message watch
 <summary><b><code>goofish message send</code></b> — 主动发消息</summary>
 
 ```bash
-$ goofish message send 60585751957 2215266653893 \
+$ goofish message send <masked-cid> <masked-user-id> \
     --text "在的 claude 测试成功 ✅" --item-id 1045171414271
 ```
 
 ```json
-{"ok": true, "mid": "1061776769407570", "cid": "60585751957"}
+{"ok": true, "mid": "<masked-message-id>", "cid": "<masked-cid>"}
 ```
 </details>
 

--- a/scripts/check_sensitive_identifiers.py
+++ b/scripts/check_sensitive_identifiers.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Reject account- and conversation-scoped identifiers in tracked text files."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+RULES = (
+    (
+        "sensitive field contains a concrete identifier",
+        re.compile(
+            r"(?i)[\"'](?:unb|tracknick|cid|toid|sessionId|userId|send_user_id|"
+            r"senderUserId|peer_user_id|mid|msg_id)[\"']\s*:\s*"
+            r"(?:[\"'](?:\d{8,}|xy\d{6,})[\"']|\d{8,})"
+        ),
+    ),
+    (
+        "sensitive cookie contains a concrete identifier",
+        re.compile(r"(?i)[\"'](?:unb|tracknick)[\"']\s*,\s*[\"'](?:\d{8,}|xy\d{6,})[\"']"),
+    ),
+    ("concrete tracknick identifier", re.compile(r"\bxy\d{8,}\b", re.IGNORECASE)),
+    (
+        "device identifier uses a concrete account identifier",
+        re.compile(r"\bgenerate_device_id\([\"']\d{8,}[\"']\)"),
+    ),
+    ("raw Xianyu message identifier", re.compile(r"\b\d{10,}\.PNM\b")),
+    ("numeric Xianyu conversation identifier", re.compile(r"\b\d{8,}@goofish\b")),
+    (
+        "message send command contains concrete identifiers",
+        re.compile(r"(?i)\bgoofish\s+message\s+send\s+\d{8,}\s+\d{8,}\b"),
+    ),
+)
+
+
+def scan_text(text: str) -> list[tuple[int, str]]:
+    findings: list[tuple[int, str]] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        for description, pattern in RULES:
+            if pattern.search(line):
+                findings.append((line_number, description))
+    return findings
+
+
+def tracked_files(repository: Path) -> list[Path]:
+    output = subprocess.check_output(
+        ["git", "ls-files", "-z"], cwd=repository, text=False
+    )
+    return [repository / path.decode() for path in output.rstrip(b"\0").split(b"\0") if path]
+
+
+def main() -> int:
+    repository = Path(__file__).resolve().parents[1]
+    findings: list[str] = []
+
+    for path in tracked_files(repository):
+        data = path.read_bytes()
+        if b"\0" in data:
+            continue
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        for line_number, description in scan_text(text):
+            findings.append(f"{path.relative_to(repository)}:{line_number}: {description}")
+
+    if findings:
+        print("Sensitive account or conversation identifiers found:")
+        print("\n".join(findings))
+        print("Replace concrete values with explicit <masked-...> or test placeholders.")
+        return 1
+
+    print("No sensitive account or conversation identifiers found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_sensitive_identifiers.py
+++ b/scripts/check_sensitive_identifiers.py
@@ -11,9 +11,9 @@ RULES = (
     (
         "sensitive field contains a concrete identifier",
         re.compile(
-            r"(?i)[\"'](?:unb|tracknick|cid|toid|sessionId|userId|send_user_id|"
-            r"senderUserId|peer_user_id|mid|msg_id)[\"']\s*:\s*"
-            r"(?:[\"'](?:\d{8,}|xy\d{6,})[\"']|\d{8,})"
+            r"(?i)(?<![\w])[\"']?(?:unb|tracknick|cid|toid|sessionId|userId|"
+            r"send_user_id|senderUserId|peer_user_id|mid|msg_id)[\"']?\s*"
+            r"(?::|=)\s*[\"']?(?:\d{8,}|xy\d{6,})(?!\d)"
         ),
     ),
     (
@@ -36,10 +36,10 @@ RULES = (
 
 def scan_text(text: str) -> list[tuple[int, str]]:
     findings: list[tuple[int, str]] = []
-    for line_number, line in enumerate(text.splitlines(), start=1):
-        for description, pattern in RULES:
-            if pattern.search(line):
-                findings.append((line_number, description))
+    for description, pattern in RULES:
+        for match in pattern.finditer(text):
+            line_number = text.count("\n", 0, match.start()) + 1
+            findings.append((line_number, description))
     return findings
 
 

--- a/tests/test_browser_cookie.py
+++ b/tests/test_browser_cookie.py
@@ -51,9 +51,9 @@ def test_available_browsers_has_edge_and_chrome():
 def test_extract_single_browser_success(monkeypatch):
     """edge 里抓到 unb/_m_h5_tk → 正常返回 (browser, cookies)。"""
     jar = _fake_jar(
-        _make_cookie("unb", "2214350705775", ".taobao.com"),
+        _make_cookie("unb", "test-unb", ".taobao.com"),
         _make_cookie("_m_h5_tk", "TOKEN_abc_123", ".taobao.com"),
-        _make_cookie("tracknick", "xy575986", ".goofish.com"),
+        _make_cookie("tracknick", "test-tracknick", ".goofish.com"),
         # 非阿里系域的 cookie，必须被过滤
         _make_cookie("sessionid", "other", ".example.com"),
     )
@@ -62,9 +62,9 @@ def test_extract_single_browser_success(monkeypatch):
 
     used, cookies = bc.extract_goofish_cookies(browser="edge")
     assert used == "edge"
-    assert cookies["unb"] == "2214350705775"
+    assert cookies["unb"] == "test-unb"
     assert cookies["_m_h5_tk"] == "TOKEN_abc_123"
-    assert cookies["tracknick"] == "xy575986"
+    assert cookies["tracknick"] == "test-tracknick"
     assert "sessionid" not in cookies
 
 

--- a/tests/test_list_chats.py
+++ b/tests/test_list_chats.py
@@ -17,23 +17,23 @@ def test_parse_session_full():
             }
         },
         "session": {
-            "ownerInfo": {"userId": "2214350705775", "nick": "x***2"},
-            "sessionId": 60585751957,
+            "ownerInfo": {"userId": "test-owner", "nick": "x***2"},
+            "sessionId": "test-cid",
             "sessionType": 1,
             "targetId": "1300",
             "userInfo": {
                 "fishNick": "小号昵称",
                 "logo": "https://x.png",
-                "nick": "xy575986224572",
+                "nick": "test-peer",
                 "type": 0,
-                "userId": "2215266653893",
+                "userId": "test-user",
             },
         },
     }
     out = _parse_session(raw)
-    assert out["session_id"] == "60585751957"
-    assert out["peer_nick"] == "xy575986224572"
-    assert out["peer_user_id"] == "2215266653893"
+    assert out["session_id"] == "test-cid"
+    assert out["peer_nick"] == "test-peer"
+    assert out["peer_user_id"] == "test-user"
     assert out["unread"] == 2
     assert out["last_msg"] == "在吗？这个还在卖吗"
     assert out["ts"] == 1776780018537
@@ -83,15 +83,15 @@ def test_parse_session_null_summary():
 
 def test_watch_record_shape():
     out = _watch_record({
-        "cid": "60585751957",
+        "cid": "test-cid",
         "session_type": 1,
-        "peer_user_id": "2215266653893",
+        "peer_user_id": "test-user",
         "item_id": "900123",
         "last_msg_id": "msg-x",
         "last_msg_ts": "1776780018537",
     })
-    assert out["session_id"] == "60585751957"
-    assert out["peer_user_id"] == "2215266653893"
+    assert out["session_id"] == "test-cid"
+    assert out["peer_user_id"] == "test-user"
     assert out["item_id"] == "900123"
     assert out["session_type"] == 1
     assert out["ts"] == 1776780018537

--- a/tests/test_sensitive_identifiers.py
+++ b/tests/test_sensitive_identifiers.py
@@ -1,4 +1,39 @@
+import pytest
+
 from scripts.check_sensitive_identifiers import scan_text
+
+ACCOUNT_FIELDS = (
+    "unb",
+    "tracknick",
+    "cid",
+    "toid",
+    "sessionId",
+    "userId",
+    "send_user_id",
+    "senderUserId",
+    "peer_user_id",
+    "mid",
+    "msg_id",
+)
+
+
+@pytest.mark.parametrize("field", ACCOUNT_FIELDS)
+@pytest.mark.parametrize(
+    "template",
+    (
+        '"{field}": "{value}"',
+        "'{field}': '{value}'",
+        "{field}: {value}",
+        '{field} = "{value}"',
+        '"{field}":\n  "{value}"',
+    ),
+)
+def test_rejects_sensitive_fields_in_common_serialization_formats(field, template):
+    identifier = "221" + "4350705775"
+
+    findings = scan_text(template.format(field=field, value=identifier))
+
+    assert findings == [(1, "sensitive field contains a concrete identifier")]
 
 
 def test_rejects_account_conversation_and_message_identifiers():
@@ -19,6 +54,18 @@ def test_rejects_account_conversation_and_message_identifiers():
     findings = scan_text(text)
 
     assert {line for line, _ in findings} == {1, 2, 3, 4, 5, 6}
+
+
+def test_rejects_cookie_header_assignments_and_tracknick_values():
+    account_id = "221" + "4350705775"
+    tracknick = "xy" + "575986224572"
+
+    findings = scan_text(f"Cookie: unb={account_id}; tracknick={tracknick}")
+
+    assert {description for _, description in findings} == {
+        "sensitive field contains a concrete identifier",
+        "concrete tracknick identifier",
+    }
 
 
 def test_allows_masked_values_fake_fixtures_and_public_item_ids():

--- a/tests/test_sensitive_identifiers.py
+++ b/tests/test_sensitive_identifiers.py
@@ -1,0 +1,33 @@
+from scripts.check_sensitive_identifiers import scan_text
+
+
+def test_rejects_account_conversation_and_message_identifiers():
+    account_id = "221" + "4350705775"
+    conversation_id = "605" + "85751957"
+    message_id = "407" + "71518" + "26249.PNM"
+    text = "\n".join(
+        [
+            f'{{"unb":"{account_id}"}}',
+            f'{{"cid":"{conversation_id}"}}',
+            f'{{"msg_ids":["{message_id}"]}}',
+            f'goofish message send {conversation_id} {account_id} --text hello',
+            f'_make_cookie("unb", "{account_id}", ".taobao.com")',
+            f'generate_device_id("{account_id}")',
+        ]
+    )
+
+    findings = scan_text(text)
+
+    assert {line for line, _ in findings} == {1, 2, 3, 4, 5, 6}
+
+
+def test_allows_masked_values_fake_fixtures_and_public_item_ids():
+    text = "\n".join(
+        [
+            '{"unb":"<masked-unb>","tracknick":"<masked-tracknick>"}',
+            '{"cid":"test-cid","send_user_id":"test-user"}',
+            "goofish item get 1045171414271",
+        ]
+    )
+
+    assert scan_text(text) == []

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -32,7 +32,7 @@ def test_generate_sign_differs_on_input():
 def test_generate_device_id():
     from goofish_cli.core.sign import generate_device_id
 
-    d1 = generate_device_id("2214350705775")
+    d1 = generate_device_id("testunb")
     # UUID 形式，后缀为 user_id
-    assert d1.endswith("-2214350705775")
+    assert d1.endswith("-testunb")
     assert len(d1.split("-")) == 6  # UUID 5 段 + user_id

--- a/tests/test_ws_codec.py
+++ b/tests/test_ws_codec.py
@@ -48,7 +48,7 @@ def test_incoming_text_new_format():
                 "text": {"text": "可以砍价吗"},
                 "reminder": {"reminderTitle": "小号昵称", "reminderContent": "可以砍价吗"},
             },
-            "senderInfo": {"senderUserId": "2217372889946"},
+            "senderInfo": {"senderUserId": "test-user"},
         },
     }
     got = extract_incoming_text(decoded)
@@ -56,7 +56,7 @@ def test_incoming_text_new_format():
         "event": "message",
         "cid": "12345",
         "content_type": 1,
-        "send_user_id": "2217372889946",
+        "send_user_id": "test-user",
         "send_user_name": "小号昵称",
         "send_message": "可以砍价吗",
     }
@@ -92,24 +92,24 @@ def test_incoming_text_legacy_format():
 def test_meta_event_read_receipt():
     """{"1":[msgIds],"2":2,"3":"cid@goofish","4":1,"5":"ts"} → 已读回执。"""
     decoded = {
-        "1": ["4066826134477.PNM", "4066820235744.PNM"],
-        "2": 2, "3": "60585751957@goofish", "4": 1, "5": "1776770736198",
+        "1": ["test-msg-1.PNM", "test-msg-2.PNM"],
+        "2": 2, "3": "test-cid@goofish", "4": 1, "5": "1776770736198",
     }
     got = extract_meta_event(decoded)
     assert got == {
-        "event": "read", "cid": "60585751957",
-        "msg_ids": ["4066826134477.PNM", "4066820235744.PNM"],
+        "event": "read", "cid": "test-cid",
+        "msg_ids": ["test-msg-1.PNM", "test-msg-2.PNM"],
         "status": 1, "ts": "1776770736198",
     }
 
 
 def test_meta_event_new_msg_notification():
     """{"1":"cid@goofish","2":1,"3":"msgId","4":"ts"} → 新消息轻量通知（无正文）。"""
-    decoded = {"1": "60585751957@goofish", "2": 1, "3": "4077151514478.PNM", "4": "1776770736064"}
+    decoded = {"1": "test-cid@goofish", "2": 1, "3": "test-msg.PNM", "4": "1776770736064"}
     got = extract_meta_event(decoded)
     assert got == {
-        "event": "new_msg", "cid": "60585751957",
-        "msg_id": "4077151514478.PNM", "ts": "1776770736064",
+        "event": "new_msg", "cid": "test-cid",
+        "msg_id": "test-msg.PNM", "ts": "1776770736064",
     }
 
 


### PR DESCRIPTION
## Summary

- remove concrete account, conversation, sender, and message identifiers from README examples and test fixtures
- scan every Git-tracked text file for concrete values in sensitive Xianyu fields, raw `.PNM` message IDs, numeric `@goofish` conversation IDs, and concrete `message send` arguments
- run the scanner in a dedicated GitHub Actions job and cover both rejected and allowed examples with unit tests

Closes #19

## Why a custom check

Generic secret scanners do not reliably classify numeric application identifiers such as `unb`, `cid`, sender IDs, and message IDs as credentials. This check enforces the repository's stricter privacy policy while still allowing explicit masked/test placeholders and unrelated public item IDs.

The scanner only reads files returned by `git ls-files`, skips binary/non-UTF-8 content, and reports the file, line, rule, and remediation hint for each finding.

## Verification

- `python3 scripts/check_sensitive_identifiers.py`
- `PYTHONPATH=src pytest -q` (`128 passed`)
- `ruff check src tests scripts`
- `git diff --check`
- targeted search for the previously committed identifiers returns no matches

## Scope

This cleans the current tree and prevents recurrence. It does not rewrite existing Git history; history removal would require a separate coordinated operation because it changes commit SHAs for all contributors.
