### PR TITLE
fix: keep MCP SDK on compatible v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 - Goofish skills now document both OpenClaw (`goofish__*`) and Claude
   (`mcp__goofish__*`) MCP tool names.
+- Constrain the MCP Python SDK to the maintained 1.x line. MCP 2.0 removes the
+  `mcp.server.fastmcp` API used by the current server and otherwise breaks clean installs.
 
 ## [0.3.0] - 2026-04-22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ dependencies = [
   "rich>=13.7",
   "pyyaml>=6.0",
   "tenacity>=8.2",
-  "mcp>=1.2",
+  # v2 renames FastMCP to MCPServer and requires a server migration.
+  # Keep the existing FastMCP implementation on the maintained v1 line for now.
+  "mcp>=1.2,<2",
   "websockets>=13",
   "browser-cookie3>=0.20",
   "playwright>=1.58.0",

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -1,0 +1,13 @@
+"""Project metadata regression checks."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_mcp_dependency_stays_on_fastmcp_compatible_major_version():
+    project_root = Path(__file__).resolve().parents[1]
+    metadata = tomllib.loads((project_root / "pyproject.toml").read_text())
+
+    assert "mcp>=1.2,<2" in metadata["project"]["dependencies"]


### PR DESCRIPTION
## 改动描述

- 将 MCP Python SDK 约束为 `mcp>=1.2,<2`，保持当前 FastMCP 服务端实现可用
- 增加项目元数据回归测试，防止依赖再次静默跨主版本
- 在 changelog 记录兼容性修复

## 动机 / 关联 issue

MCP Python SDK 2.0 删除了当前项目使用的 `mcp.server.fastmcp`，导致全新安装后 pytest 在收集阶段失败、MCP 服务无法启动。官方建议尚未迁移到 MCPServer 的项目先使用 `<2` 上限。

## 改动类型

- [x] bug 修复
- [ ] 新功能
- [ ] 重构（不改变外部行为）
- [x] 文档
- [x] CI / 构建

## 验证

- [x] 干净环境安装解析为 `mcp 1.29.0`
- [x] `pytest -q`：185 passed
- [x] `ruff check src tests`：无告警
- [x] mypy、compileall、敏感标识扫描、`pip check`：通过
- [x] MCP stdio 真实握手成功，并成功枚举 17 个工具
- [x] sdist / wheel 构建成功，wheel 元数据包含 `Requires-Dist: mcp<2,>=1.2`

## 合规

- [x] 我确认没有把 cookie / _m_h5_tk / 任何账号敏感信息 commit 进代码或测试 fixture
- [x] 我确认本 PR 不会被用于欺诈、刷单、违反闲鱼用户协议等行为
