### PR TITLE
feat(search): paginate search results with --pages N

### DIFF
--- a/src/goofish_cli/commands/search/search.py
+++ b/src/goofish_cli/commands/search/search.py
@@ -36,6 +36,15 @@ AUTH_WALL_ATTEMPTS = 2
 PAGE_STABLE_MS = 2000
 
 
+def _should_retry(payload: dict[str, Any]) -> bool:
+    """零卡片且明确 requiresAuth 时才重试（瞬时登录墙兜底）。
+
+    #28 合并后的契约：其他零卡片形态（未知页面结构等）不重试，
+    直接交给 `_raise_for_failed_page` 按语义抛错。
+    """
+    return not payload.get("items") and bool(payload.get("requiresAuth"))
+
+
 def _normalize_limit(value: Any) -> int:
     try:
         n = int(value)
@@ -292,7 +301,7 @@ async def _run(query: str, limit: int, pages: int) -> dict[str, Any]:
                 raise GoofishError("搜索页返回结构非预期")
             payload = raw
             # 拿到卡片 / 明确的空结果 / 明确的风控页都不需要重试
-            if raw.get("items") or raw.get("empty") or raw.get("blocked"):
+            if not _should_retry(raw):
                 break
             if attempt < AUTH_WALL_ATTEMPTS:
                 await asyncio.sleep(1.5)
@@ -361,6 +370,7 @@ __test__ = {
     "_normalize_pages": _normalize_pages,
     "_build_search_url": _build_search_url,
     "_item_id_from_url": _item_id_from_url,
+    "_should_retry": _should_retry,
     "_first_card_id": _first_card_id,
     "_walk_pages": _walk_pages,
 }

--- a/src/goofish_cli/commands/search/search.py
+++ b/src/goofish_cli/commands/search/search.py
@@ -222,6 +222,9 @@ async def _walk_pages(
             pag = await page.evaluate(_PAGINATION_JS)
         except Exception:  # noqa: BLE001 — 执行上下文销毁等，保留已抓结果
             return fetched_pages, total_pages, "error"
+        # 结构突变（None / 非dict）同样按优雅终止处理，不能 AttributeError 穿透
+        if not isinstance(pag, dict):
+            return fetched_pages, total_pages, "error"
 
         if total_pages is None and pag.get("totalPages") is not None:
             total_pages = pag["totalPages"]
@@ -246,6 +249,9 @@ async def _walk_pages(
         # 用 fresh 的首卡会让下一轮等待基准与 DOM �脱节（review P1-2）。
         nxt_items = nxt.get("items") or []
         anchor_id = _first_card_id(nxt_items) or anchor_id
+        # item_id 是输出的稳定主键（调用方按它去重/取详情）。解析不出数字 id
+        # 的卡片（?id=abc 等）跨页会重复追加（seen 只记非空 id），直接跳过。
+        nxt_items = [it for it in nxt_items if _item_id_from_url(it.get("url", ""))]
         fresh = [
             it for it in nxt_items if _item_id_from_url(it.get("url", "")) not in seen
         ]
@@ -294,12 +300,15 @@ async def _run(query: str, limit: int, pages: int) -> dict[str, Any]:
         assert payload is not None
         _raise_for_failed_page(payload)
 
+        # item_id 是输出的稳定主键：解析不出数字 id 的卡片直接跳过，
+        # 否则同一张坏卡跨页会重复追加（seen 只记非空 id）
         for it in payload.get("items") or []:
             item_id = _item_id_from_url(it.get("url", ""))
-            if item_id and item_id in seen:
+            if not item_id:
                 continue
-            if item_id:
-                seen.add(item_id)
+            if item_id in seen:
+                continue
+            seen.add(item_id)
             items.append(it)
         fetched_pages = 1
 

--- a/src/goofish_cli/commands/search/search.py
+++ b/src/goofish_cli/commands/search/search.py
@@ -36,11 +36,6 @@ AUTH_WALL_ATTEMPTS = 2
 PAGE_STABLE_MS = 2000
 
 
-def _should_retry(payload: dict[str, Any]) -> bool:
-    """零卡片且明确 requiresAuth 时才重试（瞬时登录墙兜底）。"""
-    return not payload.get("items") and bool(payload.get("requiresAuth"))
-
-
 def _normalize_limit(value: Any) -> int:
     try:
         n = int(value)
@@ -199,6 +194,78 @@ def _raise_for_failed_page(payload: dict[str, Any]) -> None:
         )
 
 
+async def _walk_pages(
+    page: Any,
+    items: list[dict[str, Any]],
+    seen: set[str],
+    fetched_pages: int,
+    pages: int,
+    limit: int,
+) -> tuple[int, int | None, str]:
+    """翻页状态机：点右箭头 → 等重渲染 → 去重累积。
+
+    返回 (fetched_pages, total_pages, stopped_reason)。任何翻页途中的
+    Playwright 异常（SPA 重渲染销毁执行上下文等）都被吞掉并优雅终止——
+    调用方拿到已累积的部分结果，stopped_reason 说明终止原因。
+
+    锚点（cur_first_id）始终取**未过滤**的下一页 payload 首卡：
+    fresh 是去重后的列表，若下一页首卡与上一页重复，它会被过滤掉，
+    用 fresh 的首卡做锚点会与 DOM 实况脱节，导致 page-change 等待
+    假阳性、提前终止（review P1-2）。
+    """
+    anchor_id = _first_card_id(items) or ""
+    total_pages: int | None = None
+    stopped_reason = "pages_reached"
+
+    while fetched_pages < pages and len(items) < limit:
+        try:
+            pag = await page.evaluate(_PAGINATION_JS)
+        except Exception:  # noqa: BLE001 — 执行上下文销毁等，保留已抓结果
+            return fetched_pages, total_pages, "error"
+
+        if total_pages is None and pag.get("totalPages") is not None:
+            total_pages = pag["totalPages"]
+        if not pag.get("hasNext"):
+            return fetched_pages, total_pages, "last_page"
+
+        try:
+            arrow = page.locator('[class*="pagination-arrow-container"]').nth(1)
+            await arrow.click(timeout=5000)
+            # 等待"首卡 id 不再等于上一页 DOM 首卡"。changed=False 是等待超时
+            # （重渲染大概率失败）；先看提取结果再定性。
+            changed = await page.evaluate(_WAIT_PAGE_CHANGE_JS, anchor_id)
+            await page.wait_for_timeout(PAGE_STABLE_MS)
+            nxt = await page.evaluate(_EXTRACT_JS, MAX_LIMIT)
+        except Exception:  # noqa: BLE001 — 同上，部分结果优先
+            return fetched_pages, total_pages, "error"
+        if not isinstance(nxt, dict):
+            return fetched_pages, total_pages, "error"
+
+        # 锚点更新为**未过滤** payload 的首卡（= 本页 DOM 实际首卡）。
+        # fresh 是去重后的列表：若本页首卡与上一页重复，会被过滤掉，
+        # 用 fresh 的首卡会让下一轮等待基准与 DOM �脱节（review P1-2）。
+        nxt_items = nxt.get("items") or []
+        anchor_id = _first_card_id(nxt_items) or anchor_id
+        fresh = [
+            it for it in nxt_items if _item_id_from_url(it.get("url", "")) not in seen
+        ]
+        if not fresh:
+            if not nxt_items and nxt.get("blocked"):
+                return fetched_pages, total_pages, "blocked"
+            return fetched_pages, total_pages, "no_new" if changed else "stale"
+
+        for it in fresh:
+            item_id = _item_id_from_url(it.get("url", ""))
+            if item_id:
+                seen.add(item_id)
+            items.append(it)
+        fetched_pages += 1
+
+    if len(items) >= limit:
+        return fetched_pages, total_pages, "limit"
+    return fetched_pages, total_pages, stopped_reason
+
+
 async def _run(query: str, limit: int, pages: int) -> dict[str, Any]:
     url = _build_search_url(query)
 
@@ -235,46 +302,19 @@ async def _run(query: str, limit: int, pages: int) -> dict[str, Any]:
                 seen.add(item_id)
             items.append(it)
         fetched_pages = 1
-        cur_first_id = _first_card_id(payload.get("items") or [])
 
-        # ---- 翻页：点右箭头 → 等重渲染 → 去重累积 ----
-        while fetched_pages < pages and len(items) < limit:
-            pag = await page.evaluate(_PAGINATION_JS)
-            if total_pages is None and pag.get("totalPages") is not None:
-                total_pages = pag["totalPages"]
-            if not pag.get("hasNext"):
-                break
-
-            arrow = page.locator('[class*="pagination-arrow-container"]').nth(1)
-            try:
-                await arrow.click(timeout=5000)
-            except Exception:  # noqa: BLE001 — 箭头消失/被遮挡按最后一页处理
-                break
-            await page.evaluate(_WAIT_PAGE_CHANGE_JS, cur_first_id)
-            await page.wait_for_timeout(PAGE_STABLE_MS)
-
-            nxt = await page.evaluate(_EXTRACT_JS, MAX_LIMIT)
-            if not isinstance(nxt, dict):
-                break
-            fresh = [
-                it
-                for it in (nxt.get("items") or [])
-                if _item_id_from_url(it.get("url", "")) not in seen
-            ]
-            if not fresh:
-                break  # 重渲染失败 / 重复页：防御性终止，返回已有结果
-            cur_first_id = _first_card_id(fresh)
-            for it in fresh:
-                item_id = _item_id_from_url(it.get("url", ""))
-                if item_id:
-                    seen.add(item_id)
-                items.append(it)
-            fetched_pages += 1
+        # ---- 翻页：点右箭头 → 等重渲染 → 去重累积（状态机，见 _walk_pages）----
+        fetched_pages, total_pages, stopped_reason = await _walk_pages(
+            page, items, seen, fetched_pages, pages, limit
+        )
 
         # 循环提前退出（到 limit / 末页）时补一次终态读取
         if total_pages is None:
-            pag = await page.evaluate(_PAGINATION_JS)
-            total_pages = pag.get("totalPages")
+            try:
+                pag = await page.evaluate(_PAGINATION_JS)
+                total_pages = pag.get("totalPages")
+            except Exception:  # noqa: BLE001 — 终态读取失败不影响部分结果
+                total_pages = None
 
     items = items[:limit]
     return {
@@ -285,6 +325,7 @@ async def _run(query: str, limit: int, pages: int) -> dict[str, Any]:
         "total": len(items),
         "pages_fetched": fetched_pages,
         "pages_total": total_pages,
+        "stopped_reason": stopped_reason,
         "query": "",
     }
 
@@ -311,5 +352,6 @@ __test__ = {
     "_normalize_pages": _normalize_pages,
     "_build_search_url": _build_search_url,
     "_item_id_from_url": _item_id_from_url,
-    "_should_retry": _should_retry,
+    "_first_card_id": _first_card_id,
+    "_walk_pages": _walk_pages,
 }

--- a/src/goofish_cli/commands/search/search.py
+++ b/src/goofish_cli/commands/search/search.py
@@ -5,6 +5,12 @@
 - search 没对外 API，只有 HTML 卡片 + 动态加载
 - 浏览器真实渲染天然抗风控
 
+分页（2026-08 实测）：搜索页**不是无限滚动**——窄查询滚动到底卡片数不再增长；
+翻页靠 DOM 里的 `search-pagination-container`（宽查询下 1..50 页），点击右箭头后
+SPA 内部重渲染、URL 不变，`?page=N` URL 参数被服务端忽略。所以跨页抓取 = 点击
+翻页箭头 + 按 item_id 去重累积，终止条件：达到 --pages 上限 / 右箭头 disabled /
+连续一页无新增（防御）。
+
 字段参考 OpenCLI：`item_id / rank / title / price / original_price / condition /
 brand / location / badge / url / extra`。
 """
@@ -18,10 +24,16 @@ from goofish_cli.core import Strategy, command
 from goofish_cli.core.browser import auto_scroll, goofish_page
 from goofish_cli.core.errors import AuthRequiredError, GoofishError
 
-MAX_LIMIT = 50
-# 0 卡片 + requiresAuth 时判定为疑似瞬时登录墙（同一 cookie 注入实测时好时坏），
+# limit 是**跨页总上限**（去重后条数）。站点每页 30 卡，50 页满配远超此值，
+# 200 是给 MCP 调用方的运行时护栏（每页 ~4s，200 条 ≈ 7 页 ≈ 40s）。
+MAX_LIMIT = 200
+DEFAULT_LIMIT = 20
+MAX_PAGES = 50  # 与站点分页控件一致（实测 1..50）
+# 0 卡片 + 非 empty/blocked 时判定为疑似瞬时登录墙（同一 cookie 注入实测时好时坏），
 # 总尝试次数（含首次）。重试前短暂退避，避免连续两枪都打在风控瞬间。
 AUTH_WALL_ATTEMPTS = 2
+# 点击翻页后的兜底等待；主等待靠"首卡片 id 变化"事件，这里只兜渲染卡住的底
+PAGE_STABLE_MS = 2000
 
 
 def _should_retry(payload: dict[str, Any]) -> bool:
@@ -33,8 +45,16 @@ def _normalize_limit(value: Any) -> int:
     try:
         n = int(value)
     except (TypeError, ValueError):
-        return 20
+        return DEFAULT_LIMIT
     return min(MAX_LIMIT, max(1, n))
+
+
+def _normalize_pages(value: Any) -> int:
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return 1
+    return min(MAX_PAGES, max(1, n))
 
 
 def _item_id_from_url(url: str) -> str:
@@ -121,42 +141,140 @@ _EXTRACT_JS = r"""
 })()
 """
 
+# 翻页控件状态：右箭头是否可用 + 分页盒里的最大页码（实测 1..50，"..." 是非数字盒）
+_PAGINATION_JS = r"""
+() => {
+  const boxes = [...document.querySelectorAll('[class*="page-box"]')]
+    .map((e) => (e.textContent || '').trim())
+    .filter((t) => /^\d+$/.test(t))
+    .map(Number);
+  const arrows = [...document.querySelectorAll('[class*="pagination-arrow-container"]')];
+  const right = arrows.length ? arrows[arrows.length - 1] : null;
+  return {
+    hasNext: Boolean(right) && !right.hasAttribute('disabled'),
+    totalPages: boxes.length ? Math.max(...boxes) : null,
+  };
+}
+"""
 
-async def _search_once(query: str, limit: int) -> dict[str, Any]:
-    url = _build_search_url(query)
-    async with goofish_page() as page:
-        await page.goto(url, wait_until="domcontentloaded")
-        await page.wait_for_timeout(2000)
-        await auto_scroll(page, times=2)
-        return await page.evaluate(_EXTRACT_JS, limit)
+# 翻页是 SPA 重渲染（URL 不变）。点完右箭头等"首卡片 id 变化"，最多 8s；
+# 超时返回 false（大概率是最后一页重渲染失败或内容未变，交给上层去重兜底）。
+_WAIT_PAGE_CHANGE_JS = r"""
+(prevFirstId) => new Promise((resolve) => {
+  const start = Date.now();
+  const tick = () => {
+    const first = document.querySelector('a[href*="/item?id="]');
+    const id = first ? ((first.href || '').match(/id=(\d+)/) || [])[1] : null;
+    if (id && id !== prevFirstId) return resolve(true);
+    if (Date.now() - start > 8000) return resolve(false);
+    setTimeout(tick, 200);
+  };
+  tick();
+})
+"""
 
 
-async def _run(query: str, limit: int) -> dict[str, Any]:
-    payload: dict[str, Any] | None = None
-    for attempt in range(1, AUTH_WALL_ATTEMPTS + 1):
-        raw = await _search_once(query, limit)
-        if not isinstance(raw, dict):
-            raise GoofishError("搜索页返回结构非预期")
-        payload = raw
-        if not _should_retry(raw):
-            break
-        if attempt < AUTH_WALL_ATTEMPTS:
-            await asyncio.sleep(1.5)
+def _first_card_id(items: list[dict[str, Any]]) -> str:
+    """当前页首卡 id——翻页等待的"内容已变化"基准。"""
+    for it in items:
+        item_id = _item_id_from_url(it.get("url", ""))
+        if item_id:
+            return item_id
+    return ""
 
-    assert payload is not None
+
+def _raise_for_failed_page(payload: dict[str, Any]) -> None:
+    """首页级失败（0 卡片）按原语义抛错；翻页途中的失败由调用方优雅终止。"""
     items = payload.get("items") or []
     # "登录后" 在页脚也会出现——只有在"没拿到卡片 && 命中关键词"时才判定 auth 失败
     if not items and payload.get("requiresAuth"):
         raise AuthRequiredError("www.goofish.com 搜索结果页要求登录，cookies 可能失效")
     if not items and payload.get("blocked"):
         raise GoofishError("搜索页返回验证码/安全验证（触发风控），稍后重试或换账号")
-
     if not items and not payload.get("empty"):
         preview = (payload.get("bodyPreview") or "")[:200]
         raise GoofishError(
             f"未在搜索页上解析到任何卡片，可能 DOM 结构已变。"
             f"页面文案预览：{preview!r}"
         )
+
+
+async def _run(query: str, limit: int, pages: int) -> dict[str, Any]:
+    url = _build_search_url(query)
+
+    items: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    fetched_pages = 0
+    total_pages: int | None = None
+
+    async with goofish_page() as page:
+        # ---- 第 1 页（保留瞬时登录墙重试：整页重新导航）----
+        payload: dict[str, Any] | None = None
+        for attempt in range(1, AUTH_WALL_ATTEMPTS + 1):
+            await page.goto(url, wait_until="domcontentloaded")
+            await page.wait_for_timeout(2000)
+            await auto_scroll(page, times=2)
+            raw = await page.evaluate(_EXTRACT_JS, MAX_LIMIT)
+            if not isinstance(raw, dict):
+                raise GoofishError("搜索页返回结构非预期")
+            payload = raw
+            # 拿到卡片 / 明确的空结果 / 明确的风控页都不需要重试
+            if raw.get("items") or raw.get("empty") or raw.get("blocked"):
+                break
+            if attempt < AUTH_WALL_ATTEMPTS:
+                await asyncio.sleep(1.5)
+
+        assert payload is not None
+        _raise_for_failed_page(payload)
+
+        for it in payload.get("items") or []:
+            item_id = _item_id_from_url(it.get("url", ""))
+            if item_id and item_id in seen:
+                continue
+            if item_id:
+                seen.add(item_id)
+            items.append(it)
+        fetched_pages = 1
+        cur_first_id = _first_card_id(payload.get("items") or [])
+
+        # ---- 翻页：点右箭头 → 等重渲染 → 去重累积 ----
+        while fetched_pages < pages and len(items) < limit:
+            pag = await page.evaluate(_PAGINATION_JS)
+            if total_pages is None and pag.get("totalPages") is not None:
+                total_pages = pag["totalPages"]
+            if not pag.get("hasNext"):
+                break
+
+            arrow = page.locator('[class*="pagination-arrow-container"]').nth(1)
+            try:
+                await arrow.click(timeout=5000)
+            except Exception:  # noqa: BLE001 — 箭头消失/被遮挡按最后一页处理
+                break
+            await page.evaluate(_WAIT_PAGE_CHANGE_JS, cur_first_id)
+            await page.wait_for_timeout(PAGE_STABLE_MS)
+
+            nxt = await page.evaluate(_EXTRACT_JS, MAX_LIMIT)
+            if not isinstance(nxt, dict):
+                break
+            fresh = [
+                it
+                for it in (nxt.get("items") or [])
+                if _item_id_from_url(it.get("url", "")) not in seen
+            ]
+            if not fresh:
+                break  # 重渲染失败 / 重复页：防御性终止，返回已有结果
+            cur_first_id = _first_card_id(fresh)
+            for it in fresh:
+                item_id = _item_id_from_url(it.get("url", ""))
+                if item_id:
+                    seen.add(item_id)
+                items.append(it)
+            fetched_pages += 1
+
+        # 循环提前退出（到 limit / 末页）时补一次终态读取
+        if total_pages is None:
+            pag = await page.evaluate(_PAGINATION_JS)
+            total_pages = pag.get("totalPages")
 
     items = items[:limit]
     return {
@@ -165,25 +283,32 @@ async def _run(query: str, limit: int) -> dict[str, Any]:
             for i, it in enumerate(items)
         ],
         "total": len(items),
-        "query": query,
+        "pages_fetched": fetched_pages,
+        "pages_total": total_pages,
+        "query": "",
     }
 
 
 @command(
     namespace="search",
     name="items",
-    description="搜索闲鱼商品（浏览器路径，抗风控）",
+    description="搜索闲鱼商品（浏览器路径，抗风控；--pages 跨页抓取）",
     strategy=Strategy.COOKIE,
     columns=["rank", "item_id", "title", "price", "condition", "brand", "location", "badge", "url"],
 )
-def search(query: str, limit: int = 20) -> dict[str, Any]:
-    return asyncio.run(_run(str(query).strip(), _normalize_limit(limit)))
+def search(query: str, limit: int = DEFAULT_LIMIT, pages: int = 1) -> dict[str, Any]:
+    q = str(query).strip()
+    result = asyncio.run(_run(q, _normalize_limit(limit), _normalize_pages(pages)))
+    result["query"] = q
+    return result
 
 
 __test__ = {
     "MAX_LIMIT": MAX_LIMIT,
+    "MAX_PAGES": MAX_PAGES,
     "AUTH_WALL_ATTEMPTS": AUTH_WALL_ATTEMPTS,
     "_normalize_limit": _normalize_limit,
+    "_normalize_pages": _normalize_pages,
     "_build_search_url": _build_search_url,
     "_item_id_from_url": _item_id_from_url,
     "_should_retry": _should_retry,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5,8 +5,8 @@ import asyncio
 
 import pytest
 
-from goofish_cli.commands.search.search import _item_id_from_url
 from goofish_cli.commands.search.search import __test__ as t
+from goofish_cli.commands.search.search import _item_id_from_url
 
 
 def test_normalize_limit_clamps_and_defaults():
@@ -295,3 +295,35 @@ def test_first_card_id_returns_first_with_id():
     assert f([{"url": "https://x/no-id"}, {"url": "https://www.goofish.com/item?id=42"}]) == "42"
     assert f([]) == ""
     assert f([{"url": ""}]) == ""
+
+
+def test_walk_pages_skips_cards_without_numeric_id():
+    """审核 P2：?id=abc 这类解析不出数字 id 的卡片不能跨页重复追加。"""
+    bad = {"url": "https://www.goofish.com/item?id=abc", "title": "bad-card"}
+    script = [
+        _pagination(True, 50),
+        True,
+        # 第 2 页：新卡 101 + 坏卡（坏卡跳过，不影响继续翻页）
+        {**_page_payload(["101"]), "items": [_item("101"), dict(bad)]},
+        _pagination(True, 50),
+        True,
+        # 第 3 页：坏卡再次出现 + 新卡 102（坏卡不重复追加）
+        {**_page_payload(["102"]), "items": [dict(bad), _item("102")]},
+    ]
+    items, seen = [_item("100")], {"100"}
+    fetched, _, reason = asyncio.run(
+        _walk(FakePage(script), items, seen, 1, pages=3, limit=200)
+    )
+    ids = [_item_id_from_url(it["url"]) for it in items]
+    assert ids == ["100", "101", "102"]  # 坏卡被跳过，不重复出现
+    assert fetched == 3
+    assert reason == "pages_reached"
+
+
+def test_walk_pages_non_dict_pagination_state_is_error():
+    """审核 P2：pagination 状态返回 None/非 dict 时优雅终止，不 AttributeError。"""
+    for bad in (None, [], "unexpected", 123):
+        fetched, _, reason = asyncio.run(
+            _walk(FakePage([bad]), [_item("100")], {"100"}, 1, pages=3, limit=200)
+        )
+        assert (fetched, reason) == (1, "error"), f"bad={bad!r}"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -21,6 +21,17 @@ def test_normalize_limit_clamps_and_defaults():
     assert normalize("abc") == 20
 
 
+def test_normalize_pages_clamps_and_defaults():
+    normalize = t["_normalize_pages"]
+    assert normalize(1) == 1
+    assert normalize("3") == 3
+    assert normalize(0) == 1
+    assert normalize(-2) == 1
+    assert normalize(999) == t["MAX_PAGES"]
+    assert normalize(None) == 1
+    assert normalize("abc") == 1
+
+
 def test_build_search_url_encodes_query():
     build = t["_build_search_url"]
     assert build("iPhone 15") == "https://www.goofish.com/search?q=iPhone%2015"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import patch
 
 import pytest
 
+import goofish_cli.commands.search.search as search_mod
 from goofish_cli.commands.search.search import __test__ as t
-from goofish_cli.commands.search.search import _item_id_from_url
+from goofish_cli.commands.search.search import _item_id_from_url, search
+from goofish_cli.core.errors import AuthRequiredError, GoofishError
 
 
 def test_normalize_limit_clamps_and_defaults():
@@ -83,6 +86,9 @@ class FakePage:
         return FakeLocator(self)
 
     async def evaluate(self, js: str, arg=None):
+        # auto_scroll 的滚动指令不占脚本拍，直接短路
+        if isinstance(js, str) and js.startswith("window.scrollTo"):
+            return None
         if not self.script:
             if self.on_exhausted is not None:
                 return self.on_exhausted()
@@ -93,6 +99,9 @@ class FakePage:
         return step(arg) if callable(step) else step
 
     async def wait_for_timeout(self, ms: int) -> None:
+        return None
+
+    async def goto(self, url: str, wait_until: str = "") -> None:
         return None
 
 
@@ -111,24 +120,24 @@ def _pagination(has_next: bool = True, total: int | None = 50) -> dict:
     return {"hasNext": has_next, "totalPages": total}
 
 
-def _run_walk(script, items=None, seen=None, pages=5, limit=200, **kw):
-    page = FakePage(script, **kw)
-    result = asyncio.run(_walk(page, items or [], seen or set(), 1, pages, limit))
-    return page, result
-
-
-_walk = None
-
-
-def _get_walk():
-    global _walk
-    if _walk is None:
-        _walk = t["_walk_pages"]
-    return _walk
-
-
-# 在 import t 之后绑定（模块级常量避免遮蔽）
+# 翻页状态机入口（fake page 驱动用）
 _walk = t["_walk_pages"]
+
+
+def test_should_retry_truth_table():
+    """瞬时登录墙重试谓词（#28 契约）：只有 items=[] 且 requiresAuth 才重试。
+
+    注意 `_EXTRACT_JS` 恒返回 `items` 键：真实登录墙载荷是
+    `{"items": [], "requiresAuth": True, ...}`，必须重试；
+    未知零卡片形态（requiresAuth=False）不重试，避免无谓的二次导航。
+    """
+    should_retry = t["_should_retry"]
+    assert should_retry({"items": [{"id": 1}]}) is False
+    assert should_retry({}) is False
+    assert should_retry({"requiresAuth": True}) is True
+    assert should_retry({"requiresAuth": False}) is False
+    assert should_retry({"items": [], "requiresAuth": True}) is True
+    assert should_retry({"items": [], "requiresAuth": False}) is False
 
 
 def test_walk_pages_accumulates_and_dedupes_across_pages():
@@ -327,3 +336,80 @@ def test_walk_pages_non_dict_pagination_state_is_error():
             _walk(FakePage([bad]), [_item("100")], {"100"}, 1, pages=3, limit=200)
         )
         assert (fetched, reason) == (1, "error"), f"bad={bad!r}"
+
+
+# ---------------------------------------------------------------------------
+# 公开 search() 入口回归（#28 曾发生 _run 返回 None 而测试全绿的事故，
+# 顶层组装层必须钉住：items/rank/query/分页元数据/错误传播）
+# ---------------------------------------------------------------------------
+class FakePageCtx:
+    """让 `_run` 真正执行的 goofish_page 替身：返回同一个 FakePage。"""
+
+    def __init__(self, page: FakePage) -> None:
+        self._page = page
+
+    async def __aenter__(self) -> FakePage:
+        return self._page
+
+    async def __aexit__(self, *exc) -> None:
+        return None
+
+
+def test_search_returns_ranked_items_with_metadata():
+    """成功路径：_run 组装 rank/item_id/分页元数据，search 填充 query。"""
+    # 第 1 页（extract）→ pagination → 等待 → 第 2 页 extract → 终态 pagination
+    page = FakePage(
+        [
+            _page_payload(["100", "101"]),
+            _pagination(True, 50),
+            True,
+            _page_payload(["102"]),
+            _pagination(False, 50),
+        ]
+    )
+    with patch.object(search_mod, "goofish_page", lambda **kw: FakePageCtx(page)):
+        result = search("X570", limit=50, pages=2)
+    assert result["query"] == "X570"
+    assert result["total"] == 3
+    assert result["pages_fetched"] == 2
+    assert result["pages_total"] == 50
+    assert result["stopped_reason"] == "pages_reached"
+    assert [it["rank"] for it in result["items"]] == [1, 2, 3]
+    assert [it["item_id"] for it in result["items"]] == ["100", "101", "102"]
+    assert result["items"][0]["title"] == "item-100"
+
+
+def test_search_single_page_default_contract():
+    """默认参数（pages=1, limit=20）行为与分页前一致：只抓第 1 页。"""
+    page = FakePage(
+        [
+            _page_payload([str(i) for i in range(100, 110)]),
+            _pagination(True, 50),  # 终态读取（total_pages 补取）
+        ]
+    )
+    with patch.object(search_mod, "goofish_page", lambda **kw: FakePageCtx(page)):
+        result = search("X570")
+    assert result["pages_fetched"] == 1
+    assert result["total"] == 10
+    assert result["query"] == "X570"
+
+
+def test_search_propagates_auth_required_error():
+    """登录墙错误从 _run 传播到 search() 上层（顶层契约的一部分）。"""
+    # AUTH_WALL_ATTEMPTS=2：两次导航各消费一份 extract，仍零卡片才抛
+    page = FakePage([_page_payload([], requiresAuth=True), _page_payload([], requiresAuth=True)])
+    with (
+        patch.object(search_mod, "goofish_page", lambda **kw: FakePageCtx(page)),
+        pytest.raises(AuthRequiredError, match="www.goofish.com"),
+    ):
+        search("X570")
+
+
+def test_search_propagates_structure_error():
+    """结构突变（0 卡片且非 auth/empty/blocked）按原语义从顶层抛出。"""
+    page = FakePage([_page_payload([], bodyPreview="weird page")])
+    with (
+        patch.object(search_mod, "goofish_page", lambda **kw: FakePageCtx(page)),
+        pytest.raises(GoofishError, match="DOM 结构已变"),
+    ):
+        search("X570")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,13 +1,12 @@
-"""纯函数测 search 的参数归一化和 URL 构造。真浏览器路径走 e2e 验证，不进单测。"""
+"""测 search 的参数归一化、URL 构造与 _walk_pages 翻页状态机（fake page 驱动）。"""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+import asyncio
 
 import pytest
 
+from goofish_cli.commands.search.search import _item_id_from_url
 from goofish_cli.commands.search.search import __test__ as t
-from goofish_cli.commands.search.search import search
-from goofish_cli.core.errors import AuthRequiredError
 
 
 def test_normalize_limit_clamps_and_defaults():
@@ -56,60 +55,243 @@ def test_auth_wall_attempts_is_two():
     assert t["AUTH_WALL_ATTEMPTS"] == 2
 
 
-def test_should_retry():
-    """零卡片且 requiresAuth 为真才重试（瞬时登录墙兜底）。
-
-    注意 `_EXTRACT_JS` 恒返回 `items` 键：真实登录墙载荷是
-    `{"items": [], "requiresAuth": True, ...}`，必须重试。
-    """
-    should_retry = t["_should_retry"]
-    assert should_retry({"items": [{"id": 1}]}) is False
-    assert should_retry({}) is False
-    assert should_retry({"requiresAuth": True}) is True
-    assert should_retry({"requiresAuth": False}) is False
-    assert should_retry({"items": [], "requiresAuth": True}) is True
-    assert should_retry({"items": [], "requiresAuth": True, "empty": True}) is True
-    assert should_retry({"items": [], "requiresAuth": True, "blocked": True}) is True
+# ---------------------------------------------------------------------------
+# _walk_pages 翻页状态机（fake page 驱动，确定性、无网络）
+# ---------------------------------------------------------------------------
 
 
-def test_search_returns_ranked_items_on_success():
-    """回归：_run() 成功时应返回带 rank/item_id 的 list，不能是 None。
+class FakeLocator:
+    def __init__(self, page: FakePage) -> None:
+        self._page = page
 
-    patch `_search_once`（而非 `asyncio.run`），让 `_run` 真正执行，
-    验证 rank/item_id 组装逻辑。
-    """
-    from unittest.mock import patch
+    def nth(self, i: int) -> FakeLocator:
+        return self
 
-    fake_raw = {
-        "items": [
-            {"title": "商品A", "url": "https://www.goofish.com/item?id=100", "price": "¥10"},
-            {"title": "商品B", "url": "https://www.goofish.com/item?id=200", "price": "¥20"},
-        ],
-        "requiresAuth": False,
-        "blocked": False,
-        "empty": False,
-        "bodyPreview": "",
-    }
-    with patch("goofish_cli.commands.search.search._search_once", new=AsyncMock(return_value=fake_raw)):
-        result = search("test")
-    assert result is not None
-    assert result["total"] == 2
-    assert result["items"][0]["rank"] == 1
-    assert result["items"][0]["item_id"] == "100"
-    assert result["items"][1]["rank"] == 2
-    assert result["items"][1]["item_id"] == "200"
+    async def click(self, timeout: int = 0) -> None:
+        self._page.clicks += 1
 
 
-def test_search_raises_auth_required_error():
-    """登录墙错误必须从 _run 正确传播到 search() 上层——CI 上 warning-free。"""
+class FakePage:
+    """按脚本依次返回 evaluate 结果；脚本耗尽后执行 on_exhausted。"""
 
-    def _fake_run(coro):
-        # close 掉协程防止 unawaited coroutine warning
-        coro.close()
-        raise AuthRequiredError("www.goofish.com 搜索结果页要求登录")
+    def __init__(self, script: list, on_exhausted=None) -> None:
+        self.script = list(script)
+        self.on_exhausted = on_exhausted
+        self.clicks = 0
 
-    with (
-        patch("asyncio.run", side_effect=_fake_run),
-        pytest.raises(AuthRequiredError, match="www.goofish.com"),
-    ):
-        search("test")
+    def locator(self, sel: str) -> FakeLocator:
+        return FakeLocator(self)
+
+    async def evaluate(self, js: str, arg=None):
+        if not self.script:
+            if self.on_exhausted is not None:
+                return self.on_exhausted()
+            raise AssertionError("fake page script exhausted")
+        step = self.script.pop(0)
+        if isinstance(step, Exception):
+            raise step
+        return step(arg) if callable(step) else step
+
+    async def wait_for_timeout(self, ms: int) -> None:
+        return None
+
+
+def _item(iid: str) -> dict:
+    return {"url": f"https://www.goofish.com/item?id={iid}", "title": f"item-{iid}"}
+
+
+def _page_payload(ids: list[str], **kw) -> dict:
+    base = {"items": [_item(i) for i in ids], "requiresAuth": False, "blocked": False,
+            "empty": False, "bodyPreview": ""}
+    base.update(kw)
+    return base
+
+
+def _pagination(has_next: bool = True, total: int | None = 50) -> dict:
+    return {"hasNext": has_next, "totalPages": total}
+
+
+def _run_walk(script, items=None, seen=None, pages=5, limit=200, **kw):
+    page = FakePage(script, **kw)
+    result = asyncio.run(_walk(page, items or [], seen or set(), 1, pages, limit))
+    return page, result
+
+
+_walk = None
+
+
+def _get_walk():
+    global _walk
+    if _walk is None:
+        _walk = t["_walk_pages"]
+    return _walk
+
+
+# 在 import t 之后绑定（模块级常量避免遮蔽）
+_walk = t["_walk_pages"]
+
+
+def test_walk_pages_accumulates_and_dedupes_across_pages():
+    """跨页去重：第 2 页重复第 1 页的 id 只计一次，pages_fetched 正确递增。"""
+    script = [
+        _pagination(True, 50),
+        True,  # page-change 等待
+        _page_payload(["201", "100", "202"]),  # 100 与第 1 页重复
+    ]
+    items, seen = [_item("100"), _item("101")], {"100", "101"}
+    fetched, total, reason = asyncio.run(
+        _walk(FakePage(script), items, seen, 1, pages=2, limit=200)
+    )
+    assert fetched == 2
+    assert total == 50
+    assert reason == "pages_reached"
+    ids = [_item_id_from_url(it["url"]) for it in items]
+    assert ids == ["100", "101", "201", "202"]  # 去重后顺序保持
+
+
+def test_walk_pages_anchor_uses_unfiltered_first_card():
+    """审核 P1-2：第 2 页首卡与第 1 页重复时，锚点仍取未过滤首卡，
+    第 3 页可正常到达（不再因锚点失真而提前终止）。"""
+    script = [
+        _pagination(True, 50),
+        True,  # 等待：page2 首卡 100 与 page1 重复（changed 依 DOM 而定，这里视为已变）
+        _page_payload(["100", "201", "202"]),
+        _pagination(True, 50),
+        True,
+        _page_payload(["301", "302"]),
+    ]
+    items, seen = [_item("100")], {"100"}
+    fetched, _, reason = asyncio.run(
+        _walk(FakePage(script), items, seen, 1, pages=3, limit=200)
+    )
+    assert fetched == 3
+    assert reason == "pages_reached"
+    ids = [_item_id_from_url(it["url"]) for it in items]
+    assert ids == ["100", "201", "202", "301", "302"]
+
+
+def test_walk_pages_stops_on_disabled_arrow():
+    """右箭头 disabled（末页）→ last_page，保留已有结果。"""
+    script = [_pagination(False, 1)]
+    fetched, total, reason = asyncio.run(
+        _walk(FakePage(script), [_item("100")], {"100"}, 1, pages=5, limit=200)
+    )
+    assert (fetched, total, reason) == (1, 1, "last_page")
+
+
+def test_walk_pages_stops_at_cross_page_limit():
+    """跨页 limit：累积到 limit 即停，reason=limit。"""
+    script = [
+        _pagination(True, 50),
+        True,
+        _page_payload(["201", "202"]),
+    ]
+    items, seen = [_item(f"{i}") for i in range(1, 44)], {str(i) for i in range(1, 44)}
+    fetched, _, reason = asyncio.run(
+        _walk(FakePage(script), items, seen, 1, pages=5, limit=45)
+    )
+    assert len(items) == 45
+    assert reason == "limit"
+
+
+def test_walk_pages_preserves_results_on_mid_walk_exception():
+    """审核 P1-1：翻页途中 evaluate 抛（SPA 销毁执行上下文）→
+    不抛出，返回第 1 页已累积结果 + reason=error。"""
+    boom = RuntimeError("Execution context was destroyed")
+    script = [
+        _pagination(True, 50),
+        boom,  # page-change 等待抛出
+    ]
+    items, seen = [_item("100"), _item("101")], {"100", "101"}
+    fetched, _, reason = asyncio.run(
+        _walk(FakePage(script), items, seen, 1, pages=3, limit=200)
+    )
+    assert fetched == 1
+    assert reason == "error"
+    assert len(items) == 2
+
+
+def test_walk_pages_pagination_state_exception_preserves_results():
+    """翻页第一拍（pagination 状态读取）抛出同样优雅终止。"""
+    boom = RuntimeError("Execution context was destroyed")
+    fetched, _, reason = asyncio.run(
+        _walk(FakePage([boom]), [_item("100")], {"100"}, 1, pages=3, limit=200)
+    )
+    assert (fetched, reason) == (1, "error")
+
+
+def test_walk_pages_wait_timeout_with_no_new_items_is_stale():
+    """等待超时（changed=False）且提取无新数据 → reason=stale，保留结果。"""
+    # wait JS resolve(False)；extract 返回与 seen 全重复的页
+    script = [
+        _pagination(True, 50),
+        False,
+        _page_payload(["100"]),  # 全是重复 → 无 fresh
+    ]
+    fetched, _, reason = asyncio.run(
+        _walk(FakePage(script), [_item("100")], {"100"}, 1, pages=3, limit=200)
+    )
+    assert (fetched, reason) == (1, "stale")
+
+
+def test_walk_pages_wait_timeout_but_fresh_items_continues():
+    """等待超时但提取到新数据（渲染慢而非失败）→ 照常累积继续。"""
+    script = [
+        _pagination(True, 50),
+        False,  # 等待超时
+        _page_payload(["201"]),
+        _pagination(False, 50),
+    ]
+    fetched, _, reason = asyncio.run(
+        _walk(FakePage(script), [_item("100")], {"100"}, 1, pages=5, limit=200)
+    )
+    assert fetched == 2
+    assert reason == "last_page"
+
+
+def test_walk_pages_repeated_page_is_no_new():
+    """重渲染成功但整页重复 → reason=no_new，防御性终止。"""
+    script = [
+        _pagination(True, 50),
+        True,  # changed
+        _page_payload(["100", "101"]),  # 全重复
+    ]
+    fetched, _, reason = asyncio.run(
+        _walk(FakePage(script), [_item("100"), _item("101")], {"100", "101"}, 1,
+              pages=3, limit=200)
+    )
+    assert (fetched, reason) == (1, "no_new")
+
+
+def test_walk_pages_blocked_mid_walk():
+    """翻页途中撞风控页 → reason=blocked，保留部分结果。"""
+    script = [
+        _pagination(True, 50),
+        True,
+        _page_payload([], blocked=True),
+    ]
+    fetched, _, reason = asyncio.run(
+        _walk(FakePage(script), [_item("100")], {"100"}, 1, pages=3, limit=200)
+    )
+    assert (fetched, reason) == (1, "blocked")
+
+
+def test_walk_pages_non_dict_extract_is_error():
+    """extract 返回非 dict（结构突变）→ reason=error，保留结果。"""
+    script = [
+        _pagination(True, 50),
+        True,
+        "not-a-dict",
+    ]
+    fetched, _, reason = asyncio.run(
+        _walk(FakePage(script), [_item("100")], {"100"}, 1, pages=3, limit=200)
+    )
+    assert (fetched, reason) == (1, "error")
+
+
+def test_first_card_id_returns_first_with_id():
+    """锚点函数：跳过无 id 条目，取首个可解析 id。"""
+    f = t["_first_card_id"]
+    assert f([{"url": "https://x/no-id"}, {"url": "https://www.goofish.com/item?id=42"}]) == "42"
+    assert f([]) == ""
+    assert f([{"url": ""}]) == ""


### PR DESCRIPTION
Closes #29
Depends on #28 (stacked: this branch is based on `fix/browser-cookie-dual-domain`)

## What

`goofish search items` gains `--pages N` (default `1`, fully backward compatible) to walk the search pagination control and accumulate results across pages:

```bash
goofish search items "X570" --pages 5 --limit 200
```

## Why the old approach couldn't page

Probed the live search page (2026-08, Playwright + system Chrome):

- The page is **not** infinite scroll: on a narrow query, scrolling to the bottom 3x stops growing cards (count pinned at 27, `scrollHeight` frozen) — the existing `auto_scroll` is a no-op past the first screen.
- Wide queries (`X570`) render a real pagination control: `search-pagination-container` with page boxes `1 2 3 … 50`, 30 cards per page.
- Clicking the right arrow re-renders results **in place** — the URL stays `?q=X570`. Measured page1/2/3 had **zero card overlap**.
- URL params `?page=2` / `?pageNumber=2` are ignored by the server (still return page 1).

So the only working pagination path is clicking the arrow, which the old implementation never did — `limit 50` could only ever cover ~1/50 of the results.

## Implementation

- `--pages N`: click right arrow → wait for SPA re-render by **watching the first card id change** (8s cap, `waitForFunction`-style predicate) + 2s settle → extract → dedupe by `item_id` → accumulate.
- Stop conditions (whichever first): `--pages` reached · right arrow `disabled` (last page) · `limit` reached · a page renders zero new cards (defensive against failed re-renders).
- `limit` is repurposed as the **cross-page total cap** (`MAX_LIMIT` 50 → 200); default 20 unchanged, so `pages=1` behaves exactly as before.
- Response adds `pages_fetched` / `pages_total` metadata.
- Transient auth-wall retry from #28 is preserved for page 1; mid-walk failures degrade gracefully (return partial results instead of raising).

## Tests

- New unit tests: `_normalize_pages` clamping, `MAX_PAGES` constant (190 passed total), `ruff` clean.

## Real end-to-end verification

| scenario | result |
|---|---|
| `"X570" --pages 3 --limit 200` | 90 items / 90 unique, `pages_fetched=3`, `pages_total=50`, 11s |
| `"X570 Taichi" --limit 50` (single-page query) | 26 items, `pages_fetched=1`, `pages_total=1` — stops at disabled arrow |
| `"X570" --pages 2 --limit 45` | stops at exactly 45 items across 2 pages, 45 unique |

Bonus: `pages_total=50` metadata gives callers the full result volume before deciding how deep to walk (useful for the price-research workflow that surfaced this gap).
